### PR TITLE
Warn on large file selection

### DIFF
--- a/src/components/FileSelector.js
+++ b/src/components/FileSelector.js
@@ -1,0 +1,8 @@
+function handleFileChange(event) {
+  const file = event.target.files[0];
+  if (file.size > 100 * 1024 * 1024) {
+    // Display a non-blocking warning
+    setWarning('File is very large.');
+  }
+  // ... existing code
+}


### PR DESCRIPTION
## What was broken
No warning was provided when a large file was selected.
## What changed
Added a warning when a selected file exceeds 100 MB.
## How to test
Select a file larger than 100 MB and verify a warning is displayed.

---
_Opened by autonomous agent. Human review required before merge._