### PR TITLE
fix: skip duplicate files instead of rejecting the whole batch

### DIFF
--- a/src/lib/dedupeFiles.js
+++ b/src/lib/dedupeFiles.js
@@ -1,0 +1,36 @@
+// Shared file-batch de-duplication for the "add files" flows.
+
+/** Identity of a file for duplicate detection: same name AND same size. */
+const keyOf = (file) => `${file.name}:${file.size}`
+
+/**
+ * Split an incoming batch into the files worth adding and a count of the ones
+ * skipped as duplicates. A file is a duplicate if it matches (name + size) one
+ * already in `existing` OR one earlier in the same batch, so a selection that
+ * repeats a file adds it only once. Order of the kept files is preserved.
+ *
+ * @param {File[]} existing - files already in the list
+ * @param {File[]} incoming - the newly selected batch
+ * @returns {{ unique: File[], skipped: number }}
+ */
+export function dedupeFiles(existing, incoming) {
+  const seen = new Set(existing.map(keyOf))
+  const unique = []
+  let skipped = 0
+  for (const file of incoming) {
+    const key = keyOf(file)
+    if (seen.has(key)) {
+      skipped += 1
+      continue
+    }
+    seen.add(key)
+    unique.push(file)
+  }
+  return { unique, skipped }
+}
+
+/** "Skipped N file(s) already added", or '' when nothing was skipped. */
+export function skippedNotice(skipped) {
+  if (skipped < 1) return ''
+  return `Skipped ${skipped} file${skipped > 1 ? 's' : ''} already added`
+}

--- a/src/operations/images-to-pdf/index.jsx
+++ b/src/operations/images-to-pdf/index.jsx
@@ -6,31 +6,24 @@ import Note from '../../components/Note.jsx'
 import DownloadButton from '../../components/DownloadButton.jsx'
 import Icon from '../../components/Icon.jsx'
 import { useJob } from '../../hooks/useJob.js'
+import { dedupeFiles, skippedNotice } from '../../lib/dedupeFiles.js'
 import { imagesToPdf } from './helpers.js'
 
 export default function ImagesToPdf() {
   const [files, setFiles] = useState([])
+  const [notice, setNotice] = useState('')
   const [pageSize, setPageSize] = useState('fit')
   const [orientation, setOrientation] = useState('auto')
   const [margin, setMargin] = useState(0)
-  const { running, progress, error, setError, result, run, reset } = useJob();
+  const { running, progress, error, result, run, reset } = useJob()
 
   const addFiles = (incoming) => {
-    const duplicate = incoming.find((f) =>
-      files.some(
-        (existing) => existing.name === f.name && existing.size === f.size,
-      ),
-    );
-    if (duplicate) {
-      setError(`Duplicate file: ${duplicate.name}`);
-      return;
-    }
-    setFiles((prev) => [
-      ...prev,
-      ...incoming.filter((f) => f.type.startsWith("image/")),
-    ]);
-    reset();
-  };
+    const images = incoming.filter((f) => f.type.startsWith('image/'))
+    const { unique, skipped } = dedupeFiles(files, images)
+    if (unique.length) setFiles((prev) => [...prev, ...unique])
+    setNotice(skippedNotice(skipped))
+    reset()
+  }
   const move = (from, to) =>
     setFiles((prev) => {
       const next = [...prev]
@@ -65,6 +58,7 @@ export default function ImagesToPdf() {
             onRemove={remove}
             onClear={() => {
               setFiles([])
+              setNotice('')
               reset()
             }}
             icon="image"
@@ -130,6 +124,7 @@ export default function ImagesToPdf() {
         </>
       )}
 
+      {notice && <Note type="warning">{notice}</Note>}
       {running && progress && <Progress value={progress.value} message={progress.message} />}
       {error && <Note type="error" title="Couldn’t create the PDF">{error}</Note>}
       {result && !running && (

--- a/src/operations/merge-pdfs/index.jsx
+++ b/src/operations/merge-pdfs/index.jsx
@@ -6,28 +6,21 @@ import Note from '../../components/Note.jsx'
 import Icon from '../../components/Icon.jsx'
 import DownloadButton from '../../components/DownloadButton.jsx'
 import { useJob } from '../../hooks/useJob.js'
+import { dedupeFiles, skippedNotice } from '../../lib/dedupeFiles.js'
 import { mergePdfs } from './helpers.js'
 
 export default function MergePdfs() {
   const [files, setFiles] = useState([])
-  const { running, progress, error, setError, result, run, reset } = useJob();
+  const [notice, setNotice] = useState('')
+  const { running, progress, error, result, run, reset } = useJob()
 
   const add = (incoming) => {
-    const duplicate = incoming.find((f) =>
-      files.some(
-        (existing) => existing.name === f.name && existing.size === f.size,
-      ),
-    );
-    if (duplicate) {
-      setError(`Duplicate file: ${duplicate.name}`);
-      return;
-    }
-    setFiles((prev) => [
-      ...prev,
-      ...incoming.filter((f) => /pdf$/i.test(f.type) || /\.pdf$/i.test(f.name)),
-    ]);
-    reset();
-  };
+    const pdfs = incoming.filter((f) => /pdf$/i.test(f.type) || /\.pdf$/i.test(f.name))
+    const { unique, skipped } = dedupeFiles(files, pdfs)
+    if (unique.length) setFiles((prev) => [...prev, ...unique])
+    setNotice(skippedNotice(skipped))
+    reset()
+  }
   const move = (from, to) =>
     setFiles((prev) => {
       const next = [...prev]
@@ -44,7 +37,7 @@ export default function MergePdfs() {
 
       {files.length > 0 && (
         <>
-          <FileList files={files} onMove={move} onRemove={(i) => setFiles((p) => p.filter((_, idx) => idx !== i))} onClear={() => { setFiles([]); reset() }} />
+          <FileList files={files} onMove={move} onRemove={(i) => setFiles((p) => p.filter((_, idx) => idx !== i))} onClear={() => { setFiles([]); setNotice(''); reset() }} />
           <div className="flex flex-wrap items-center gap-3">
             <button type="button" className="btn-primary" onClick={merge} disabled={running || files.length < 2}>
               <Icon name="layers" className="h-4 w-4" />
@@ -55,6 +48,7 @@ export default function MergePdfs() {
         </>
       )}
 
+      {notice && <Note type="warning">{notice}</Note>}
       {running && progress && <Progress value={progress.value} message={progress.message} />}
       {error && <Note type="error" title="Merge failed">{error}</Note>}
     </div>


### PR DESCRIPTION
Closes #32 (follow-up to #15 / #30)

## Change

Both `merge-pdfs` and `images-to-pdf` previously called `setError("Duplicate file: …")` and `return`ed on the first already-added file, throwing away the whole selection. Now the add handlers:

- filter the batch to the accepted type first, then keep only files not already present (matched on **name + size**), adding the rest;
- also drop files repeated **within the same selection** (a growing `Set` of `name:size`), so a selection can never introduce a duplicate;
- show a brief, non-blocking `Note type="warning"` — "Skipped N file(s) already added" — **only** when something was skipped (cleared on the next clean add and on Clear).

The de-dup + message live in a new `src/lib/dedupeFiles.js` (matching the repo's `src/lib` util pattern and no-semicolon / single-quote style), used by both handlers so they stay in sync.

## Verification

Ran the dev server and drove both tools by injecting file batches:

**merge-pdfs**
- batch `[a.pdf, b.pdf]` → both added, **no** notice
- then `[a.pdf (dup), c.pdf, c.pdf]` → list becomes `a·b·c` (each once), notice **"Skipped 2 files already added"**
- then `[a.pdf]` → notice **"Skipped 1 file already added"** (singular)

**images-to-pdf** — same script (`x,y` then `x(dup),z,z`) → `x·y·z` each once, **"Skipped 2 files already added"**.

No console errors; `npm run build` passes. Covers all four acceptance criteria (adds new + skips dups, within-selection repeat added once, notice only when skipped, no duplicate entries).