### PR TITLE
Enhancement 12 - Invert Image

### DIFF
--- a/src/operations/invert-image/helper.js
+++ b/src/operations/invert-image/helper.js
@@ -1,0 +1,28 @@
+import { decode, canvasToBlob } from "../../lib/imageCanvas.js"
+import { outName } from "../../lib/imageFormat.js"
+/**
+ * @param {File} file
+ */
+export async function invertImage(file, onProgress) {
+    onProgress?.(0.3, 'Decoding image…')
+    const bitmap = await decode(file)
+
+    onProgress?.(0.6, 'Inverting colors…')
+    const canvas = document.createElement('canvas')
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+
+    const ctx = canvas.getContext('2d')
+    ctx.filter = 'invert(1)'
+    ctx.drawImage(bitmap, 0, 0)
+    bitmap.close?.()
+
+    // Keep the source format so the file extension/type stays predictable.
+    const format = /png$/i.test(file.type) || /\.png$/i.test(file.name) ? 'png' : 'jpeg'
+
+    onProgress?.(0.9, 'Encoding…')
+    const blob = await canvasToBlob(canvas, format, 0.92)
+
+    onProgress?.(1, 'Done')
+    return { blob, filename: outName(file.name, format), before: file.size, after: blob.size }
+}

--- a/src/operations/invert-image/index.jsx
+++ b/src/operations/invert-image/index.jsx
@@ -1,0 +1,46 @@
+import { useState } from "react"
+import Dropzone from "../../components/Dropzone.jsx"
+import Progress from "../../components/Progress.jsx"
+import Note from "../../components/Note.jsx"
+import ImageResult from "../../components/ImageResult.jsx"
+import Icon from "../../components/Icon.jsx"
+import { invertImage } from "./helper"
+import { useJob } from "../../hooks/useJob.js"
+import { formatBytes } from "../../lib/format.js"
+
+
+export default function InvertImage() {
+    const [file, setFile] = useState(null)
+    const { running, progress, error, result, run, reset } = useJob()
+
+    const pick = (files) => {
+        setFile(files[0])
+        reset()
+    }
+    const go = () => run((p) => invertImage(file, p))
+
+    return (
+        <div className="space-y-6">
+            <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" icon="image" />
+
+            {file && (
+                <>
+                    <div className="card flex items-center gap-3 p-3">
+                        <Icon name="image" className="h-5 w-5 text-brand-600" />
+                        <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+                        <span className="text-xs text-slate-400">{formatBytes(file.size)}</span>
+                    </div>
+
+                    <button type="button" className="btn-primary" onClick={go} disabled={running}>
+                        <Icon name="contrast" className="h-4 w-4" />
+                        Invert colors
+                    </button>
+                </>
+            )}
+
+            {running && progress && <Progress value={progress.value} message={progress.message} />}
+            {error && <Note type="error" title="Invert failed">{error}</Note>}
+            {result && !running && <ImageResult result={result} />}
+        </div>
+    )
+}

--- a/src/operations/invert-image/meta.js
+++ b/src/operations/invert-image/meta.js
@@ -1,0 +1,8 @@
+export default {
+    id: 'invert-image',
+    name: 'Invert Image Colors',
+    description: 'Invert the colors of an image and download the result.',
+    category: 'image',
+    icon: 'invert',
+    order: 21,
+}


### PR DESCRIPTION
**Issue Number:**
Closes #12 - Invert image colour completely using js

**Summary of Changes:**
Added a new "Invert Image Colors" tool under src/operations/invert-image/:

helper.js — decodes the image using imageCanvas, applies CSS invert(1) filter via Canvas API, re-encodes in the source format (PNG or JPEG), and returns the blob with before/after sizes.

index.jsx — UI with a dropzone, invert button, progress indicator, error note, and image result preview.

meta.js — registers the tool in the sidebar under the image category with order 21.

No new dependencies — uses existing imageCanvas, imageFormat, useJob, and shared components.

**Testing/Validation:**

Dropped a PNG and JPEG — both inverted correctly and downloaded in their original format.

Verified no network requests are made (DevTools → Network tab shows only local origin).

Tested offline after first load — tool works fully without a connection.

Confirmed error note appears when an unsupported/corrupt file is dropped.

**Screenshots:**
This feature is completely new and it was not present beforehand in the ui

After adding the feature

<img width="1457" height="485" alt="image" src="https://github.com/user-attachments/assets/a0225cf9-0173-41aa-b8d1-0df6a1d39f94" />
<img width="1918" height="1037" alt="image" src="https://github.com/user-attachments/assets/d4b23544-166e-420e-8f91-865eab567e99" />

**Additional Notes:**

WebP input falls back to JPEG output since the format check only distinguishes PNG vs everything else — could be a follow-up improvement.

ctx.filter (CSS filter on Canvas) has broad browser support but is not available in some older browsers — acceptable given the project's modern-browser target.

Also the sidebar is not scrollable, I personally feel that should be scrollable with the functions that could be acted upon image be also present in there.