### PR TITLE
Add Invert Image operation

### DIFF
--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -100,6 +100,9 @@ const P = {
   home: '<path d="m3 10 9-7 9 7v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 21V12h6v9"/>',
   panelLeft: '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M9 4v16"/>',
   sparkles: '<path d="M12 3v4M12 17v4M3 12h4M17 12h4M6 6l2 2M16 16l2 2M18 6l-2 2M8 16l-2 2"/>',
+
+  // invert-image
+  invert: '<circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 0 1 0 18z"/>',
 }
 
 export const iconNames = Object.keys(P)

--- a/src/operations/invert-image/helpers.js
+++ b/src/operations/invert-image/helpers.js
@@ -1,0 +1,39 @@
+import { decode, drawToCanvas, canvasToBlob } from '../../lib/imageCanvas.js'
+import { formatFromType, outName } from '../../lib/imageFormat.js'
+
+export async function invertImage(file, opts, onProgress) {
+  const { quality = 0.95 } = opts || {}
+  onProgress?.(0.3, 'Decoding image…')
+  const bitmap = await decode(file)
+  const fmt = formatFromType(file.type)
+  onProgress?.(0.5, 'Inverting colours…')
+
+  // Draw the bitmap onto a canvas so we can read pixel data.
+  const bg = fmt === 'jpeg' ? '#ffffff' : undefined
+  const canvas = drawToCanvas(bitmap, { background: bg })
+  const ctx = canvas.getContext('2d')
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  const data = imageData.data
+
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 255 - data[i]       // R
+    data[i + 1] = 255 - data[i + 1] // G
+    data[i + 2] = 255 - data[i + 2] // B
+    // data[i + 3] — alpha is preserved as-is
+  }
+
+  ctx.putImageData(imageData, 0, 0)
+  bitmap.close?.()
+
+  onProgress?.(0.8, 'Encoding…')
+  const blob = await canvasToBlob(canvas, fmt, quality)
+  onProgress?.(1, 'Done')
+  return {
+    blob,
+    filename: outName(file.name, fmt, '-inverted'),
+    before: file.size,
+    after: blob.size,
+    width: canvas.width,
+    height: canvas.height,
+  }
+}

--- a/src/operations/invert-image/index.jsx
+++ b/src/operations/invert-image/index.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import ImageResult from '../../components/ImageResult.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes } from '../../lib/format.js'
+import { invertImage } from './helpers.js'
+
+export default function InvertImage() {
+  const [file, setFile] = useState(null)
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const pick = (files) => {
+    setFile(files[0])
+    reset()
+  }
+  const go = () => run((p) => invertImage(file, {}, p))
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        accept="image/*"
+        multiple={false}
+        label="Drop an image here or click to browse"
+        hint="JPEG, PNG, and WebP are supported"
+        icon="image"
+      />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="image" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+            <span className="text-xs text-slate-400">{formatBytes(file.size)}</span>
+          </div>
+          <button type="button" className="btn-primary" onClick={go} disabled={running}>
+            <Icon name="invert" className="h-4 w-4" />
+            Invert colours
+          </button>
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && <Note type="error" title="Inversion failed">{error}</Note>}
+      {result && !running && <ImageResult result={result} />}
+    </div>
+  )
+}

--- a/src/operations/invert-image/meta.js
+++ b/src/operations/invert-image/meta.js
@@ -1,0 +1,10 @@
+export default {
+  id: 'invert-image',
+  name: 'Invert Image',
+  description: 'Invert colours — turn every pixel into its complementary colour.',
+  category: 'image',
+  icon: 'invert',
+  order: 25,
+  notes:
+    'Inversion is applied per pixel (R, G, B channels independently). The alpha channel is preserved as-is. PNG transparency is kept; JPEG results get a white background.',
+}


### PR DESCRIPTION
Closes #39

New operation: inverts every pixel's RGB channels to their complementary colour while preserving the alpha channel.

- meta.js: metadata (id, name, description, category: image, order: 25)
- helpers.js: decodes image, reads pixel data via canvas ImageData, inverts R/G/B channels
- index.jsx: dropzone -> file display -> action button -> ImageResult
- Added 'invert' icon to Icon.jsx (filled semicircle glyph)

Follows the plugin/registry pattern auto-discovered by import.meta.glob -- no central registration needed.

**Acceptance criteria**
- [x] New operation appears in sidebar under Image category
- [x] Image drops in, inverts correctly, downloads result
- [x] npm run build succeeds
- [x] Works with DevTools Network tab showing zero external requests