### PR TITLE
Enable CodeQL security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Closes #48

- GitHub CodeQL analysis workflow for JavaScript/TypeScript
- Runs on PR, push to main, and weekly schedule (Monday 6 AM)
- Uses security-and-quality query suite
- Requires security-events write permission

**Acceptance criteria**
- [x] CodeQL workflow exists at .github/workflows/codeql.yml
- [x] Analyzes javascript-typescript
- [x] Runs on PR, push, and weekly schedule