### PR TITLE
Add CI: build + lint on every PR (#42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-lint:
+    name: Build + Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run build


### PR DESCRIPTION
Closes #42

- GitHub Actions workflow that runs on PRs and pushes to main
- Steps: checkout, setup Node 22, npm ci, npm run lint, npm run build
- Concurrency group with cancel-in-progress to avoid wasted runs

⚠️ Depends on #55 (ESLint config) — the  script in package.json is added there.

**Acceptance criteria**
- [x] CI runs `npm run lint` (0 errors expected, after #55 merges)
- [x] CI runs `npm run build` (production build succeeds)
- [x] Workflow triggers on PR to main and push to main