### PR TITLE
Closes #28: whole window drag and drop implementation done

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import { useTheme } from './hooks/useTheme.js'
 import { useLocalStorage } from './hooks/useLocalStorage.js'
 import { useDocumentTitle } from './hooks/useDocumentTitle.js'
 import { getOperation } from './registry/registry.js'
+import { emitFileDrop } from './lib/fileDropBus.js'
 
 // Hash routing. An empty hash (or #/ or #/home) means the Home landing page
 // (activeId === null); #/<id> opens that tool.
@@ -43,6 +44,7 @@ export default function App() {
   const [activeId, select] = useHashSelection()
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
   const [collapsed, setCollapsed] = useLocalStorage('doxdock:sidebarCollapsed', false)
 
   const activeOp = activeId ? getOperation(activeId) : null
@@ -59,6 +61,42 @@ export default function App() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  useEffect(() => {
+    let dragCounter = 0
+
+    const onDragEnter = (e) => {
+      e.preventDefault()
+      dragCounter++
+      if (e.dataTransfer?.types?.includes('Files')) setIsDragging(true)
+    }
+    const onDragOver = (e) => { e.preventDefault() }
+    const onDragLeave = (e) => {
+      e.preventDefault()
+      dragCounter--
+      if (dragCounter <= 0) { dragCounter = 0; setIsDragging(false) }
+    }
+    const onDrop = (e) => {
+      e.preventDefault()
+      dragCounter = 0
+      setIsDragging(false)
+      const file = e.dataTransfer?.files?.[0]
+      if (!file) return
+      emitFileDrop(file)
+    }
+
+    window.addEventListener('dragenter', onDragEnter)
+    window.addEventListener('dragover', onDragOver)
+    window.addEventListener('dragleave', onDragLeave)
+    window.addEventListener('drop', onDrop)
+
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter)
+      window.removeEventListener('dragover', onDragOver)
+      window.removeEventListener('dragleave', onDragLeave)
+      window.removeEventListener('drop', onDrop)
+    }
   }, [])
 
   const handleSelect = (id) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -134,6 +134,14 @@ export default function App() {
 
   return (
     <div className="flex h-full flex-col">
+      {isDragging && (
+        <div className="pointer-events-none fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-brand-900/40 backdrop-blur-sm">
+          <div className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-brand-400 bg-white/90 px-12 py-10 shadow-2xl dark:bg-slate-900/90">
+            <Icon name="upload" className="h-10 w-10 text-brand-500" />
+            <p className="text-lg font-semibold text-brand-700 dark:text-brand-300">Drop your file anywhere</p>
+          </div>
+        </div>
+      )}
       {/* Top bar */}
       <header className="z-20 flex items-center gap-3 border-b border-slate-200 bg-white/80 px-4 py-3 backdrop-blur dark:border-slate-800 dark:bg-slate-950/80">
         <button

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,6 +79,7 @@ export default function App() {
     }
     const onDrop = (e) => {
       e.preventDefault()
+      e.stopPropagation()
       dragCounter = 0
       setIsDragging(false)
       const file = e.dataTransfer?.files?.[0]

--- a/src/components/Dropzone.jsx
+++ b/src/components/Dropzone.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useCallback, useId } from 'react'
 import Icon from './Icon.jsx'
 import { cx } from '../lib/format.js'
+import { useFileDrop } from '../hooks/useFileDrop.js'
 
 // Reusable drag-and-drop dropzone + file picker. Keyboard accessible (Enter/Space
 // opens the picker). Files never leave the browser — they are handed straight to
@@ -35,6 +36,13 @@ export default function Dropzone({
   )
 
   const open = () => inputRef.current?.click()
+
+  // Route window-wide drops (anywhere outside this box) into the same file pipeline.
+  const onWindowFileDrop = useCallback(
+    (file) => handleFiles([file]),
+    [handleFiles],
+  )
+  useFileDrop(onWindowFileDrop)
 
   return (
     <div

--- a/src/hooks/useFileDrop.js
+++ b/src/hooks/useFileDrop.js
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+import { registerFileDropHandler } from "../lib/fileDropBus";
+
+
+export function useFileDrop(onFile){
+useEffect(()=>{
+    const unregister = registerFileDropHandler(onFile)
+    return unregister;
+}, [onFile])
+}

--- a/src/hooks/useFileDrop.js
+++ b/src/hooks/useFileDrop.js
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { registerFileDropHandler } from "../lib/fileDropBus";
+import { useEffect } from 'react'
+import { registerFileDropHandler } from '../lib/fileDropBus'
 
 
 export function useFileDrop(onFile){

--- a/src/lib/fileDropBus.js
+++ b/src/lib/fileDropBus.js
@@ -1,0 +1,17 @@
+let handler = null;
+
+export function registerFileDropHandler(fn){
+    handler = fn;
+    return () => {
+        if(handler === fn) handler = null;
+    }
+}
+
+export function emitFileDrop(file){
+    if(handler) {
+        handler(file);
+        return true;
+    }
+    return false;
+}
+

--- a/src/lib/fileDropBus.js
+++ b/src/lib/fileDropBus.js
@@ -1,17 +1,17 @@
 let handler = null;
 
 export function registerFileDropHandler(fn){
-    handler = fn;
+    handler = fn
     return () => {
-        if(handler === fn) handler = null;
+        if (handler === fn) handler = null
     }
 }
 
 export function emitFileDrop(file){
     if(handler) {
-        handler(file);
-        return true;
+        handler(file)
+        return true
     }
-    return false;
+    return false
 }
 


### PR DESCRIPTION
**Issue Number:**
Closes #28 

**Summary of Changes:**
Implemented a global file drop feature — users can now drag and drop a file anywhere on the window (not just onto the Dropzone) and it gets routed to the active tool's file handler automatically.

fileDropBus.js (new) — a lightweight singleton event bus with two functions: registerFileDropHandler(fn) registers the active dropzone's handler and returns an unregister cleanup function; emitFileDrop(file) fires the currently registered handler with the dropped file.

useFileDrop.js (new) — a React hook that calls registerFileDropHandler inside a useEffect, automatically unregistering on unmount. Each Dropzone calls this to subscribe itself as the active handler.

Dropzone.jsx — added useFileDrop(onWindowFileDrop) so every Dropzone instance subscribes to window-wide drops. When a file is dropped anywhere outside the Dropzone box, it flows through the bus into the same handleFiles pipeline.

App.jsx — added global dragenter, dragover, dragleave, and drop event listeners on window. Uses a dragCounter to correctly track enter/leave across nested elements and sets isDragging state for a visual overlay. On drop, calls emitFileDrop(file) to route the file to whichever Dropzone is currently active.

**Testing/Validation:**

Dropped a file onto the window background (outside the Dropzone box) — confirmed it routes correctly to the active tool.

Verified isDragging visual feedback appears on drag enter and clears on drag leave and drop.

Confirmed no duplicate file handling when dropping directly onto the Dropzone itself.

Verified cleanup — switching tools unregisters the previous Dropzone handler and registers the new one.

**Additional Notes:**

fileDropBus holds only one handler at a time (the most recently mounted Dropzone). This is intentional — only the visible active tool should receive the drop. If multiple Dropzones are mounted simultaneously, the last one to mount wins.