### PR TITLE
feat: per-tool SEO — path routing, per-page meta, build-time prerender

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/prerender.mjs",
     "preview": "vite preview",
     "gen:icons": "node scripts/generate-icons.mjs"
   },

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+// Post-build prerender for SEO. DoxDock is a client-side SPA, so a crawler that
+// does not run JS would otherwise see one empty page. This script takes the built
+// dist/index.html and, for every tool, writes dist/<id>/index.html with:
+//   - a unique <title>, description, canonical, and Open Graph / Twitter tags
+//   - real crawlable content inside #root (an <h1>, the description, a privacy
+//     line, and links to every other tool)
+// React replaces #root on load (createRoot, not hydrate), so this content is only
+// ever seen by crawlers and on first paint. It also regenerates sitemap.xml.
+//
+// Uses only Node built-ins. Meta is read straight from each operation's meta.js.
+
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const dist = path.join(root, 'dist')
+const opsDir = path.join(root, 'src', 'operations')
+
+const SITE = 'https://doxdock.vercel.app'
+const DEFAULT_DESC =
+  'Free, open-source PDF & image tools that run 100% in your browser — merge, split, compress, convert, edit, and sign. No uploads, no sign-up, fully private and offline.'
+
+const escText = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+const escAttr = (s) => escText(s).replace(/"/g, '&quot;')
+
+// Load operation metadata (id/name/description/order) straight from meta.js.
+async function loadOps() {
+  const ops = []
+  for (const entry of readdirSync(opsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const metaPath = path.join(opsDir, entry.name, 'meta.js')
+    if (!existsSync(metaPath)) continue
+    const mod = await import(pathToFileURL(metaPath).href)
+    const m = mod.default || mod
+    ops.push({ id: m.id || entry.name, name: m.name, description: m.description || '', order: m.order ?? 100 })
+  }
+  return ops.sort((a, b) => a.order - b.order || a.name.localeCompare(b.name))
+}
+
+// Replace the whole <meta>/<link> tag that contains `idSubstr` with `newTag`.
+function swapTag(html, idSubstr, newTag) {
+  const esc = idSubstr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`<(?:meta|link)\\b[^>]*${esc}[^>]*>`, 'i')
+  if (!re.test(html)) {
+    console.warn(`  prerender: could not find tag for ${idSubstr}`)
+    return html
+  }
+  return html.replace(re, newTag)
+}
+
+function injectRoot(html, block) {
+  const re = /<div id="root">\s*<\/div>/i
+  if (!re.test(html)) throw new Error('prerender: <div id="root"></div> not found in dist/index.html')
+  return html.replace(re, `<div id="root">${block}</div>`)
+}
+
+const WRAP = (inner) =>
+  `<main style="max-width:760px;margin:0 auto;padding:2.5rem 1.5rem;font-family:system-ui,-apple-system,sans-serif;line-height:1.6">${inner}</main>`
+
+function toolBlock(op, ops) {
+  const links = ops.map((o) => `<li><a href="/${o.id}">${escText(o.name)}</a></li>`).join('')
+  return WRAP(
+    `<h1>${escText(op.name)}</h1>` +
+      `<p>${escText(op.description)}</p>` +
+      `<p>DoxDock runs 100% in your browser. Your files are never uploaded to any server — no sign-up, works offline, and it is open source.</p>` +
+      `<p><a href="/">← All DoxDock tools</a></p>` +
+      `<nav aria-label="All tools"><h2>All tools</h2><ul>${links}</ul></nav>`,
+  )
+}
+
+function homeBlock(ops) {
+  const links = ops
+    .map((o) => `<li><a href="/${o.id}">${escText(o.name)}</a> — ${escText(o.description)}</li>`)
+    .join('')
+  return WRAP(
+    `<h1>DoxDock — Private PDF &amp; Image Tools</h1>` +
+      `<p>${escText(DEFAULT_DESC)}</p>` +
+      `<nav aria-label="All tools"><h2>All tools</h2><ul>${links}</ul></nav>`,
+  )
+}
+
+function toolPage(template, op, ops) {
+  const title = `${op.name} — DoxDock`
+  const description = `${op.description} Runs 100% in your browser — no uploads, no sign-up, fully private.`
+  const url = `${SITE}/${op.id}`
+  let html = template
+  html = html.replace(/<title>[\s\S]*?<\/title>/i, `<title>${escText(title)}</title>`)
+  html = swapTag(html, 'name="description"', `<meta name="description" content="${escAttr(description)}" />`)
+  html = swapTag(html, 'rel="canonical"', `<link rel="canonical" href="${escAttr(url)}" />`)
+  html = swapTag(html, 'property="og:title"', `<meta property="og:title" content="${escAttr(title)}" />`)
+  html = swapTag(html, 'property="og:description"', `<meta property="og:description" content="${escAttr(description)}" />`)
+  html = swapTag(html, 'property="og:url"', `<meta property="og:url" content="${escAttr(url)}" />`)
+  html = swapTag(html, 'name="twitter:title"', `<meta name="twitter:title" content="${escAttr(title)}" />`)
+  html = swapTag(html, 'name="twitter:description"', `<meta name="twitter:description" content="${escAttr(description)}" />`)
+  html = injectRoot(html, toolBlock(op, ops))
+  return html
+}
+
+function sitemap(ops) {
+  const urls = ['/', ...ops.map((o) => `/${o.id}`)]
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    urls.map((u) => `  <url><loc>${SITE}${u}</loc></url>`).join('\n') +
+    `\n</urlset>\n`
+  )
+}
+
+const indexPath = path.join(dist, 'index.html')
+if (!existsSync(indexPath)) {
+  console.error('prerender: dist/index.html not found — run `vite build` first.')
+  process.exit(1)
+}
+
+const template = readFileSync(indexPath, 'utf-8')
+const ops = await loadOps()
+
+let count = 0
+for (const op of ops) {
+  const dir = path.join(dist, op.id)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path.join(dir, 'index.html'), toolPage(template, op, ops))
+  count++
+}
+
+// Home page: keep the default meta, just inject crawlable content + tool links.
+writeFileSync(indexPath, injectRoot(template, homeBlock(ops)))
+writeFileSync(path.join(dist, 'sitemap.xml'), sitemap(ops))
+
+console.log(`✅ prerendered ${count} tool pages + home + sitemap.xml (${ops.length + 1} URLs)`)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,15 +10,16 @@ import Home from './components/Home.jsx'
 import OSCodeNavBadge from './components/OSCodeNavBadge.jsx'
 import { useTheme } from './hooks/useTheme.js'
 import { useLocalStorage } from './hooks/useLocalStorage.js'
-import { useDocumentTitle } from './hooks/useDocumentTitle.js'
+import { useSeo } from './hooks/useSeo.js'
 import { getOperation } from './registry/registry.js'
 import { emitFileDrop } from './lib/fileDropBus.js'
 
-// Hash routing. An empty hash (or #/ or #/home) means the Home landing page
-// (activeId === null); #/<id> opens that tool.
-function useHashSelection() {
+// Path routing for SEO — each tool gets its own crawlable URL ("/merge-pdfs").
+// "/" (or an unknown path) → Home landing page (activeId === null).
+// Legacy hash links ("/#/merge-pdfs") are redirected to the path form on load.
+function useRouteSelection() {
   const parse = () => {
-    const raw = window.location.hash.replace(/^#\/?/, '')
+    const raw = decodeURIComponent(window.location.pathname).replace(/^\/+|\/+$/g, '')
     if (!raw || raw === 'home') return null
     return getOperation(raw) ? raw : null
   }
@@ -26,14 +27,21 @@ function useHashSelection() {
 
   const select = useCallback((id) => {
     setActiveId(id)
-    const target = id ? `#/${id}` : '#/'
-    if (window.location.hash !== target) window.location.hash = target
+    const target = id ? `/${id}` : '/'
+    if (window.location.pathname !== target) window.history.pushState({}, '', target)
   }, [])
 
   useEffect(() => {
-    const onHash = () => setActiveId(parse())
-    window.addEventListener('hashchange', onHash)
-    return () => window.removeEventListener('hashchange', onHash)
+    // Redirect old hash-style links ("/#/merge-pdfs") to the path form.
+    const legacy = window.location.hash.match(/^#\/?(.*)$/)
+    if (legacy) {
+      const id = legacy[1] === 'home' ? '' : legacy[1]
+      window.history.replaceState({}, '', (getOperation(id) ? `/${id}` : '/') + window.location.search)
+      setActiveId(getOperation(id) ? id : null)
+    }
+    const onPop = () => setActiveId(parse())
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
   }, [])
 
   return [activeId, select]
@@ -41,7 +49,7 @@ function useHashSelection() {
 
 export default function App() {
   const [theme, setTheme] = useTheme()
-  const [activeId, select] = useHashSelection()
+  const [activeId, select] = useRouteSelection()
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
@@ -49,7 +57,7 @@ export default function App() {
 
   const activeOp = activeId ? getOperation(activeId) : null
 
-  useDocumentTitle(activeOp ? `${activeOp.name} — DoxDock` : 'DoxDock')
+  useSeo(activeOp)
 
   // Global Cmd/Ctrl+K to open the palette.
   useEffect(() => {
@@ -163,7 +171,7 @@ export default function App() {
         >
           <Icon name="panelLeft" className="h-5 w-5" />
         </button>
-        <a href="#/" className="flex items-center gap-2" onClick={() => handleSelect(null)}>
+        <a href="/" className="flex items-center gap-2" onClick={(e) => { e.preventDefault(); handleSelect(null) }}>
           <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-600 text-white">
             <Icon name="layers" className="h-5 w-5" />
           </span>

--- a/src/hooks/useSeo.js
+++ b/src/hooks/useSeo.js
@@ -1,0 +1,34 @@
+import { useEffect } from 'react'
+
+// Keeps the document's SEO/social tags in sync with the active tool as the user
+// navigates client-side. The tags themselves already exist in index.html (and in
+// the prerendered per-tool pages) — this just updates them in place so a
+// JS-rendering crawler and social-share scrapers see the right title/description.
+const SITE = 'https://doxdock.vercel.app'
+const DEFAULT_TITLE = 'DoxDock — Private PDF & Image Tools, 100% in Your Browser'
+const DEFAULT_DESC =
+  'Free, open-source PDF & image tools that run 100% in your browser — merge, split, compress, convert, edit, and sign. No uploads, no sign-up, fully private and offline.'
+
+function setAttr(selector, attr, value) {
+  const el = document.head.querySelector(selector)
+  if (el) el.setAttribute(attr, value)
+}
+
+export function useSeo(op) {
+  useEffect(() => {
+    const title = op ? `${op.name} — DoxDock` : DEFAULT_TITLE
+    const description = op
+      ? `${op.description} Runs 100% in your browser — no uploads, no sign-up, fully private.`
+      : DEFAULT_DESC
+    const url = op ? `${SITE}/${op.id}` : `${SITE}/`
+
+    document.title = title
+    setAttr('meta[name="description"]', 'content', description)
+    setAttr('link[rel="canonical"]', 'href', url)
+    setAttr('meta[property="og:title"]', 'content', title)
+    setAttr('meta[property="og:description"]', 'content', description)
+    setAttr('meta[property="og:url"]', 'content', url)
+    setAttr('meta[name="twitter:title"]', 'content', title)
+    setAttr('meta[name="twitter:description"]', 'content', description)
+  }, [op])
+}

--- a/src/operations/edit-pdf/index.jsx
+++ b/src/operations/edit-pdf/index.jsx
@@ -436,7 +436,7 @@ export default function EditPdf() {
     exportJob.run((p) => exportEditedPdf(bytesRef.current, annos, p).then((blob) => ({ blob, filename: finalName() })))
 
   const openStandalone = () => {
-    const url = `${window.location.origin}${window.location.pathname}?standalone=1#/edit-pdf`
+    const url = `${window.location.origin}/edit-pdf?standalone=1`
     window.open(url, '_blank', 'noopener,noreferrer')
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Phase 1 discoverability work: makes every tool independently indexable.

- **Path routing** (`/merge-pdfs`) instead of hash, with legacy-hash redirect + standalone pop-out updated.
- **useSeo** hook syncs title/description/canonical/OG per tool on client nav.
- **Prerender** (`scripts/prerender.mjs` after `vite build`) writes a real `dist/<id>/index.html` per tool with unique meta + crawlable content, and regenerates `sitemap.xml` (24 URLs).
- **vercel.json** clean URLs + SPA fallback.

Verified locally: deep-link, legacy-hash redirect, client-side nav, and standalone mode all resolve to the right tool with correct meta; build + prerender succeed; no console errors.