### PR TITLE
feat: Edit PDF Metadata tool

### DIFF
--- a/src/operations/pdf-metadata/helpers.js
+++ b/src/operations/pdf-metadata/helpers.js
@@ -1,0 +1,71 @@
+import { PDFDocument } from 'pdf-lib'
+
+/** The editable document-info fields, in display order. */
+export const METADATA_FIELDS = [
+  { key: 'title', label: 'Title' },
+  { key: 'author', label: 'Author' },
+  { key: 'subject', label: 'Subject' },
+  { key: 'keywords', label: 'Keywords', hint: 'Comma-separated' },
+  { key: 'creator', label: 'Creator', hint: 'The app that created the original document' },
+  { key: 'producer', label: 'Producer', hint: 'The app that produced the PDF' },
+]
+
+export function emptyMetadata() {
+  return { title: '', author: '', subject: '', keywords: '', creator: '', producer: '' }
+}
+
+async function loadDoc(file) {
+  try {
+    // updateMetadata: false — don’t let pdf-lib silently rewrite Producer/ModDate;
+    // the exported file should contain exactly what the user sees in the form.
+    return await PDFDocument.load(await file.arrayBuffer(), { updateMetadata: false })
+  } catch {
+    throw new Error('Could not read this PDF. Encrypted PDFs are not supported.')
+  }
+}
+
+/**
+ * Read the document-info metadata of a PDF.
+ * @param {File} file
+ * @returns {Promise<{title:string, author:string, subject:string, keywords:string, creator:string, producer:string}>}
+ */
+export async function readPdfMetadata(file) {
+  const doc = await loadDoc(file)
+  return {
+    title: doc.getTitle() || '',
+    author: doc.getAuthor() || '',
+    subject: doc.getSubject() || '',
+    keywords: doc.getKeywords() || '',
+    creator: doc.getCreator() || '',
+    producer: doc.getProducer() || '',
+  }
+}
+
+/**
+ * Write (or clear — empty string clears) the document-info metadata and export the PDF.
+ * @param {File} file
+ * @param {{title:string, author:string, subject:string, keywords:string, creator:string, producer:string}} meta
+ */
+export async function writePdfMetadata(file, meta, onProgress) {
+  onProgress?.(0.1, 'Loading PDF…')
+  const doc = await loadDoc(file)
+  onProgress?.(0.5, 'Writing metadata…')
+  doc.setTitle(meta.title || '')
+  doc.setAuthor(meta.author || '')
+  doc.setSubject(meta.subject || '')
+  // pdf-lib wants keywords as a list (it joins them with spaces into the PDF's single
+  // Keywords string). Split on commas when present (preserves multi-word phrases),
+  // otherwise on whitespace — so a value read from an existing PDF round-trips unchanged.
+  const rawKeywords = (meta.keywords || '').trim()
+  doc.setKeywords(
+    rawKeywords
+      .split(rawKeywords.includes(',') ? ',' : /\s+/)
+      .map((k) => k.trim())
+      .filter(Boolean),
+  )
+  doc.setCreator(meta.creator || '')
+  doc.setProducer(meta.producer || '')
+  onProgress?.(0.8, 'Saving…')
+  const bytes = await doc.save()
+  return new Blob([bytes], { type: 'application/pdf' })
+}

--- a/src/operations/pdf-metadata/index.jsx
+++ b/src/operations/pdf-metadata/index.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import DownloadButton from '../../components/DownloadButton.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes, baseName } from '../../lib/format.js'
+import { usePdfPageCount } from '../../hooks/usePdfPageCount.js'
+import { METADATA_FIELDS, emptyMetadata, readPdfMetadata, writePdfMetadata } from './helpers.js'
+
+export default function PdfMetadata() {
+  const [file, setFile] = useState(null)
+  const [meta, setMeta] = useState(null)
+  const [loadError, setLoadError] = useState('')
+  const { running, progress, error, result, run, reset } = useJob()
+  const { pageCount } = usePdfPageCount(file)
+
+  const pick = async (files) => {
+    const f = files[0]
+    setFile(f)
+    setMeta(null)
+    setLoadError('')
+    reset()
+    try {
+      setMeta(await readPdfMetadata(f))
+    } catch (e) {
+      setLoadError(e.message)
+    }
+  }
+
+  const setField = (key) => (e) => setMeta({ ...meta, [key]: e.target.value })
+
+  const go = () =>
+    run((p) =>
+      writePdfMetadata(file, meta, p).then((blob) => ({
+        blob,
+        filename: `${baseName(file.name)}-metadata.pdf`,
+      })),
+    )
+
+  return (
+    <div className="space-y-6">
+      <Dropzone onFiles={pick} accept="application/pdf,.pdf" multiple={false} label="Drop a PDF here or click to browse" icon="fileText" />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="fileText" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+            <span className="text-xs text-slate-400">{formatBytes(file.size)}{pageCount != null && ` · ${pageCount} page${pageCount === 1 ? '' : 's'}`}</span>
+          </div>
+
+          {meta && (
+            <>
+              <div className="card p-4">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {METADATA_FIELDS.map(({ key, label, hint }) => (
+                    <label key={key} className="space-y-1">
+                      <span className="field-label">{label}</span>
+                      <input type="text" className="field-input" value={meta[key]} onChange={setField(key)} placeholder={hint || ''} />
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button type="button" className="btn-primary" onClick={go} disabled={running}>
+                  <Icon name="pencil" className="h-4 w-4" />
+                  Save metadata
+                </button>
+                <button type="button" className="btn-secondary" onClick={() => setMeta(emptyMetadata())} disabled={running}>
+                  <Icon name="eraser" className="h-4 w-4" />
+                  Clear all
+                </button>
+                {result && <DownloadButton result={result} />}
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {loadError && <Note type="error" title="Couldn’t read metadata">{loadError}</Note>}
+      {error && <Note type="error" title="Couldn’t save metadata">{error}</Note>}
+    </div>
+  )
+}

--- a/src/operations/pdf-metadata/meta.js
+++ b/src/operations/pdf-metadata/meta.js
@@ -1,0 +1,8 @@
+export default {
+  id: 'pdf-metadata',
+  name: 'Edit PDF Metadata',
+  description: 'View and edit a PDF’s title, author, subject, keywords, creator and producer — or clear them all.',
+  category: 'pdf',
+  icon: 'info',
+  order: 26,
+}


### PR DESCRIPTION
Closes #92

Adds `src/operations/pdf-metadata/` following the plugin pattern — `meta.js` / `index.jsx` / `helpers.js`, auto-discovered, reusing `Dropzone`, `useJob`, `Progress`, `Note`, `DownloadButton`, `usePdfPageCount`. No new dependencies (pdf-lib is already bundled) and zero network requests at runtime.

**Behavior**
- Drop a PDF → the six document-info fields (Title, Author, Subject, Keywords, Creator, Producer) pre-fill with the current metadata. Loading uses `updateMetadata: false` so pdf-lib never rewrites Producer/ModDate behind the user's back — the exported file contains exactly what the form shows.
- Edit any field, or **Clear all**, then **Save metadata** → exports `<name>-metadata.pdf`.
- Keywords fidelity: the PDF `Keywords` entry is one string and pdf-lib space-joins its list. The form splits on commas when present (preserving multi-word phrases like `data science, ml`), otherwise on whitespace — so a value read from an existing PDF round-trips unchanged.
- Encrypted PDFs get the same friendly error message as the other pdf-lib tools.

**Verified end-to-end in the dev build** (all client-side):
- Generated a PDF with title/author/subject/keywords/creator set → fields pre-fill correctly.
- Edited Title + Keywords → the downloaded blob, re-opened with pdf-lib, shows `New Better Title` / the edited keywords; untouched fields preserved.
- Clear all → exported PDF has every info field empty.
- Network log for the whole flow: zero requests.
