### PR TITLE
feat: Sanitize PDF — strip JavaScript, embedded files & hidden data

### DIFF
--- a/src/operations/sanitize-pdf/helpers.js
+++ b/src/operations/sanitize-pdf/helpers.js
@@ -1,0 +1,289 @@
+import { PDFDocument, PDFName, PDFDict, PDFArray, PDFRef } from 'pdf-lib'
+
+// Document surgery on the PDF object graph. Each removal unlinks a dictionary
+// entry AND purges the objects it owned, so the payload bytes actually leave the
+// file (see `purge`). Page content streams and resources are never touched, so
+// the visible pages come out identical.
+
+const NAME = {
+  names: PDFName.of('Names'),
+  javaScript: PDFName.of('JavaScript'),
+  embeddedFiles: PDFName.of('EmbeddedFiles'),
+  openAction: PDFName.of('OpenAction'),
+  aa: PDFName.of('AA'),
+  acroForm: PDFName.of('AcroForm'),
+  metadata: PDFName.of('Metadata'),
+  annots: PDFName.of('Annots'),
+  subtype: PDFName.of('Subtype'),
+  s: PDFName.of('S'),
+  a: PDFName.of('A'),
+  af: PDFName.of('AF'),
+  fileAttachment: PDFName.of('FileAttachment'),
+  javaScriptAction: PDFName.of('JavaScript'),
+}
+
+// Info-dictionary keys a PDF carries. Blanking these and dropping the XMP
+// stream covers both metadata surfaces. setKeywords takes an array, the rest
+// take strings — hence the explicit list rather than a uniform loop.
+const INFO_KEYS = ['Title', 'Author', 'Subject', 'Keywords', 'Producer', 'Creator']
+
+// pdf-lib's typed lookup THROWS when the key is missing rather than returning
+// undefined, and most of these entries are optional. These wrappers return
+// undefined instead, so a plain PDF with no Names/AcroForm/Annots is not an error.
+function lookupDict(dict, name) {
+  if (!dict?.has?.(name)) return undefined
+  const value = dict.lookup(name)
+  return value instanceof PDFDict ? value : undefined
+}
+
+function lookupArray(dict, name) {
+  if (!dict?.has?.(name)) return undefined
+  const value = dict.lookup(name)
+  return value instanceof PDFArray ? value : undefined
+}
+
+/**
+ * Delete `value` and everything it references from the file.
+ *
+ * Unlinking a dictionary entry only drops the REFERENCE — pdf-lib does not
+ * garbage-collect, so the object's bytes (the script source, the attachment
+ * stream) would still be sitting in the saved PDF and recoverable with any
+ * parser. For a sanitizer that is the whole point, so each removal purges the
+ * object graph it owned.
+ *
+ * Only ever called on subtrees that are exclusively owned by the thing being
+ * removed — JS actions, embedded-file streams, the XMP packet — never on page
+ * resources, which can be shared.
+ */
+function purge(context, value, seen = new Set()) {
+  if (value instanceof PDFRef) {
+    const key = value.toString()
+    if (seen.has(key)) return
+    seen.add(key)
+    const resolved = context.lookup(value)
+    purge(context, resolved, seen)
+    context.delete(value)
+    return
+  }
+  if (value instanceof PDFArray) {
+    for (let i = 0; i < value.size(); i++) purge(context, value.get(i), seen)
+    return
+  }
+  // A stream's dict is walked the same way; PDFRawStream exposes .dict.
+  const dict = value instanceof PDFDict ? value : value?.dict
+  if (dict instanceof PDFDict) {
+    for (const [, entry] of dict.entries()) purge(context, entry, seen)
+  }
+}
+
+/** Unlink a key from `dict` and purge whatever it pointed at. */
+function removeEntry(context, dict, name) {
+  if (!dict?.has?.(name)) return false
+  purge(context, dict.get(name))
+  dict.delete(name)
+  return true
+}
+
+/** True when `dict` is an action dictionary whose /S is /JavaScript. */
+function isJavaScriptAction(dict) {
+  if (!(dict instanceof PDFDict)) return false
+  const type = dict.get(NAME.s)
+  return type === NAME.javaScriptAction
+}
+
+/** Remove the document-level JavaScript name tree and any JS action hooks. */
+function removeJavaScript(doc) {
+  let removed = 0
+  const catalog = doc.catalog
+  const ctx = doc.context
+
+  // 1. Catalog /Names /JavaScript — the document-level JS name tree.
+  const names = lookupDict(catalog, NAME.names)
+  if (removeEntry(ctx, names, NAME.javaScript)) removed++
+
+  // 2. /OpenAction — only when it is a JS action; a plain "go to page 1"
+  //    OpenAction is harmless navigation and worth preserving.
+  const openAction = catalog.has(NAME.openAction) ? catalog.lookup(NAME.openAction) : undefined
+  if (isJavaScriptAction(openAction)) {
+    if (removeEntry(ctx, catalog, NAME.openAction)) removed++
+  }
+
+  // 3. Additional-actions dictionaries, which fire on document and page events.
+  if (removeEntry(ctx, catalog, NAME.aa)) removed++
+
+  for (const page of doc.getPages()) {
+    if (removeEntry(ctx, page.node, NAME.aa)) removed++
+    for (const annot of annotationDicts(page)) {
+      if (removeEntry(ctx, annot, NAME.aa)) removed++
+      if (annot.has(NAME.a) && isJavaScriptAction(annot.lookup(NAME.a))) {
+        if (removeEntry(ctx, annot, NAME.a)) removed++
+      }
+    }
+  }
+
+  // 4. Form-field additional actions (keystroke/format/validate JS).
+  const acroForm = lookupDict(catalog, NAME.acroForm)
+  if (removeEntry(ctx, acroForm, NAME.aa)) removed++
+
+  return removed
+}
+
+/** Remove attached/embedded files and any file-attachment annotations. */
+function removeEmbeddedFiles(doc) {
+  let removed = 0
+  const catalog = doc.catalog
+  const ctx = doc.context
+
+  const names = lookupDict(catalog, NAME.names)
+  if (removeEntry(ctx, names, NAME.embeddedFiles)) removed++
+
+  // Associated files (PDF 2.0) hang off the catalog and off pages.
+  if (removeEntry(ctx, catalog, NAME.af)) removed++
+
+  for (const page of doc.getPages()) {
+    if (removeEntry(ctx, page.node, NAME.af)) removed++
+    // A FileAttachment annotation carries its own embedded stream, so the
+    // annotation itself has to go, not just the name tree entry.
+    const kept = []
+    const annots = lookupArray(page.node, NAME.annots)
+    if (!annots) continue
+    for (let i = 0; i < annots.size(); i++) {
+      const ref = annots.get(i)
+      const dict = page.node.context.lookup(ref, PDFDict)
+      if (dict?.get(NAME.subtype) === NAME.fileAttachment) {
+        purge(ctx, ref)
+        removed++
+        continue
+      }
+      kept.push(ref)
+    }
+    if (kept.length !== annots.size()) {
+      page.node.set(NAME.annots, page.node.context.obj(kept))
+    }
+  }
+
+  return removed
+}
+
+/** Delete the Info-dictionary entries and drop the XMP metadata stream. */
+function removeMetadata(doc) {
+  let removed = 0
+
+  // Delete the entries outright rather than setting them to "" — an empty
+  // string is still a present key, and pdf-lib's setters would re-add
+  // ModDate/Producer anyway.
+  const info = doc.context.lookup(doc.context.trailerInfo.Info)
+  if (info instanceof PDFDict) {
+    for (const key of INFO_KEYS) {
+      const name = PDFName.of(key)
+      if (info.has(name)) {
+        info.delete(name)
+        removed++
+      }
+    }
+    // Timestamps are metadata too, and leak when a document was worked on.
+    for (const key of ['CreationDate', 'ModDate']) {
+      const name = PDFName.of(key)
+      if (info.has(name)) {
+        info.delete(name)
+        removed++
+      }
+    }
+  }
+
+  // The XMP packet duplicates the same fields in XML and is missed by tools
+  // that only clear the Info dictionary.
+  if (removeEntry(doc.context, doc.catalog, NAME.metadata)) removed++
+  return removed
+}
+
+/** Drop every annotation (links, comments, stamps, form widgets). */
+function removeAnnotations(doc) {
+  let removed = 0
+  for (const page of doc.getPages()) {
+    const annots = lookupArray(page.node, NAME.annots)
+    if (annots && annots.size() > 0) {
+      removed += annots.size()
+      removeEntry(doc.context, page.node, NAME.annots)
+    }
+  }
+  // Widget annotations are the visual half of form fields; with them gone the
+  // AcroForm entry only references orphans.
+  if (removed > 0) removeEntry(doc.context, doc.catalog, NAME.acroForm)
+  return removed
+}
+
+/** The annotation dictionaries on a page, resolved from their refs. */
+function annotationDicts(page) {
+  const annots = lookupArray(page.node, NAME.annots)
+  if (!annots) return []
+  const out = []
+  for (let i = 0; i < annots.size(); i++) {
+    const dict = page.node.context.lookup(annots.get(i), PDFDict)
+    if (dict) out.push(dict)
+  }
+  return out
+}
+
+/**
+ * Strip unwanted content from a PDF. Entirely client-side; only dictionary
+ * entries are removed, so page content streams — and therefore the visible
+ * pages — are unchanged.
+ *
+ * @param {File} file
+ * @param {{javascript?:boolean, embeddedFiles?:boolean, metadata?:boolean, annotations?:boolean}} opts
+ */
+export async function sanitizePdf(file, opts, onProgress) {
+  const {
+    javascript = true,
+    embeddedFiles = true,
+    metadata = true,
+    annotations = false,
+  } = opts || {}
+
+  if (!javascript && !embeddedFiles && !metadata && !annotations) {
+    throw new Error('Choose at least one thing to remove.')
+  }
+
+  onProgress?.(0.1, 'Reading PDF…')
+  let doc
+  try {
+    doc = await PDFDocument.load(await file.arrayBuffer())
+  } catch {
+    throw new Error('Could not read this PDF. Encrypted PDFs are not supported.')
+  }
+
+  const report = { javascript: 0, embeddedFiles: 0, metadata: 0, annotations: 0 }
+
+  if (javascript) {
+    onProgress?.(0.3, 'Removing JavaScript…')
+    report.javascript = removeJavaScript(doc)
+  }
+  if (embeddedFiles) {
+    onProgress?.(0.5, 'Removing embedded files…')
+    report.embeddedFiles = removeEmbeddedFiles(doc)
+  }
+  if (annotations) {
+    onProgress?.(0.65, 'Removing annotations…')
+    report.annotations = removeAnnotations(doc)
+  }
+  // Metadata runs last: the passes above can leave pdf-lib's own Producer
+  // stamp behind, and blanking afterwards keeps the output clean.
+  if (metadata) {
+    onProgress?.(0.8, 'Removing metadata…')
+    report.metadata = removeMetadata(doc)
+  }
+
+  onProgress?.(0.9, 'Writing PDF…')
+  const bytes = await doc.save({ useObjectStreams: false })
+  const blob = new Blob([bytes], { type: 'application/pdf' })
+  onProgress?.(1, 'Done')
+
+  return {
+    blob,
+    filename: file.name.replace(/\.pdf$/i, '') + '-clean.pdf',
+    before: file.size,
+    after: blob.size,
+    report,
+  }
+}

--- a/src/operations/sanitize-pdf/index.jsx
+++ b/src/operations/sanitize-pdf/index.jsx
@@ -1,0 +1,131 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import DownloadButton from '../../components/DownloadButton.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes } from '../../lib/format.js'
+import { sanitizePdf } from './helpers.js'
+
+const OPTIONS = [
+  {
+    key: 'javascript',
+    label: 'Embedded JavaScript',
+    hint: 'Document scripts, open actions and event handlers',
+  },
+  {
+    key: 'embeddedFiles',
+    label: 'Attached files',
+    hint: 'Files carried inside the PDF, including attachment annotations',
+  },
+  {
+    key: 'metadata',
+    label: 'Metadata',
+    hint: 'Title, author, timestamps and the XMP packet',
+  },
+  {
+    key: 'annotations',
+    label: 'Annotations',
+    hint: 'Comments, links, stamps and form fields — changes what you see',
+  },
+]
+
+export default function SanitizePdf() {
+  const [file, setFile] = useState(null)
+  // Annotations are off by default: unlike the others they are visible content.
+  const [opts, setOpts] = useState({
+    javascript: true,
+    embeddedFiles: true,
+    metadata: true,
+    annotations: false,
+  })
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const pick = (files) => {
+    setFile(files[0])
+    reset()
+  }
+  const toggle = (key) => {
+    setOpts((prev) => ({ ...prev, [key]: !prev[key] }))
+    reset()
+  }
+  const nothingSelected = !Object.values(opts).some(Boolean)
+  const go = () => run((p) => sanitizePdf(file, opts, p))
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        accept="application/pdf"
+        multiple={false}
+        label="Drop a PDF here or click to browse"
+        hint="PDFs can carry scripts, hidden attachments and metadata you did not intend to share"
+        icon="lock"
+      />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="layers" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+            <span className="text-xs text-slate-400">{formatBytes(file.size)}</span>
+          </div>
+
+          <div className="card space-y-3 p-4">
+            <span className="field-label">Remove</span>
+            {OPTIONS.map(({ key, label, hint }) => (
+              <label key={key} className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={opts[key]}
+                  onChange={() => toggle(key)}
+                  className="mt-1 accent-brand-600"
+                />
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium">{label}</span>
+                  <span className="block text-xs text-slate-400">{hint}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={go}
+              disabled={running || nothingSelected}
+            >
+              <Icon name="lock" className="h-4 w-4" />
+              Sanitize PDF
+            </button>
+            {result && !running && <DownloadButton result={result} />}
+          </div>
+
+          {nothingSelected && <Note type="info">Choose at least one thing to remove.</Note>}
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && <Note type="error" title="Couldn’t sanitize this PDF">{error}</Note>}
+      {result && !running && (
+        <Note type="info" title="Done">
+          {summarize(result.report)} The visible pages are unchanged.
+        </Note>
+      )}
+    </div>
+  )
+}
+
+/** A plain-language summary of what came out, rather than raw counts. */
+function summarize(report) {
+  if (!report) return ''
+  const parts = []
+  if (report.javascript > 0) parts.push('embedded JavaScript')
+  if (report.embeddedFiles > 0) parts.push('attached files')
+  if (report.metadata > 0) parts.push('metadata')
+  if (report.annotations > 0) parts.push(`${report.annotations} annotation(s)`)
+  if (parts.length === 0) return 'This PDF had none of the selected items — nothing to remove.'
+  return `Removed: ${parts.join(', ')}.`
+}

--- a/src/operations/sanitize-pdf/meta.js
+++ b/src/operations/sanitize-pdf/meta.js
@@ -1,0 +1,10 @@
+export default {
+  id: 'sanitize-pdf',
+  name: 'Sanitize PDF',
+  description: 'Strip embedded JavaScript, attached files, metadata and annotations.',
+  category: 'pdf',
+  icon: 'lock',
+  order: 14,
+  notes:
+    'Removes the entries themselves, not just the links to them — the script source and attachment bytes actually leave the file, so they cannot be recovered by a parser. Page content is untouched, so the document looks exactly the same.',
+}


### PR DESCRIPTION
Adds a `sanitize-pdf` operation: pick a PDF, tick what to strip, download the cleaned file.

Follows the plugin pattern — self-contained `src/operations/sanitize-pdf/{meta.js,index.jsx,helpers.js}`, auto-discovered by the registry glob with no central wiring, reusing `Dropzone`, `useJob`, `Note`, `Progress`, `Icon` and `DownloadButton`.

## The part that actually matters: unlinking is not removing

My first version deleted the catalog entries (`/Names /JavaScript`, `/Names /EmbeddedFiles`, `/Metadata`) — which is the obvious reading of "pdf-lib document surgery". I tested it and the output **still contained `app.alert(...)` and `payload.exe`**.

pdf-lib doesn't garbage-collect. Unlinking drops the *reference*; the object bytes stay in the saved file and any parser can still recover them. For a security tool that's the whole point, so each removal now walks and deletes the object graph it owned (`purge` in `helpers.js`). That's only ever applied to subtrees exclusively owned by the removed item — JS actions, embedded-file streams, the XMP packet — never page resources, which can be shared.

## What each option removes

- **Embedded JavaScript** — the `/Names /JavaScript` name tree, a JS `/OpenAction`, document and page `/AA`, annotation `/A` JS actions, and AcroForm `/AA` (keystroke/format/validate scripts). A *non-JS* `OpenAction` is preserved, since "go to page 1" is harmless navigation.
- **Attached files** — the `/EmbeddedFiles` name tree, `/AF` associated files on the catalog and pages, and `FileAttachment` annotations (which carry their own stream, so the annotation itself has to go).
- **Metadata** — Info-dictionary entries *including* `CreationDate`/`ModDate`, plus the XMP packet. Entries are deleted rather than set to `""`, since an empty string is still a present key.
- **Annotations** — opt-in and **default off**, because unlike the other three these are visible content. The issue lists it as a checkbox, so it's there, just not on by default.

## Verification

Built a hostile PDF (document-level JS, `payload.exe` attachment, XMP packet, Info metadata, a FileAttachment annotation and a normal Link) and checked the output bytes:

| | before | after |
|---|---|---|
| `app.alert` | present | **gone** |
| `/EmbeddedFiles` | present | **gone** |
| `payload.exe` | present | **gone** |
| XMP packet | present | **gone** |
| `/FileAttachment` | present | **gone** |

Against the acceptance criteria:

- **Visible page content unchanged** — extracted text with pdf.js before and after: both `"KEEP THIS TEXT"`. Content streams and resources are never touched.
- **Runs fully offline** — network log during a full sanitize run shows only `localhost` requests; no CDN, no external asset, nothing added to `package.json` (pdf-lib is already a dependency). Respects the `connect-src 'self'` CSP.
- **Selected items absent** — table above.

Also checked the edges: a plain PDF with none of these features is a clean no-op rather than an error (this caught two real bugs — pdf-lib's typed `lookup` *throws* on a missing key, and `setKeywords` rejects a string); a normal `Link` annotation survives with annotations off and is removed with it on; and unticking everything is blocked in the UI and guarded in the helper.

## End-to-end in the app

Dropped the hostile PDF into the running dev server, ticked the defaults, hit **Sanitize PDF**, and captured the produced blob:

```
note:     "Removed: embedded JavaScript, attached files, metadata. The visible pages are unchanged."
download: hostile-clean.pdf (852 B)
captured blob → app.alert: false, payload.exe: false
```

No console errors.
