### PR TITLE
feat: Watermark an image (text or logo)

### DIFF
--- a/src/operations/watermark-image/helpers.js
+++ b/src/operations/watermark-image/helpers.js
@@ -1,0 +1,157 @@
+import { decode, dimsOf, canvasToBlob } from '../../lib/imageCanvas.js'
+import { formatFromType, outName } from '../../lib/imageFormat.js'
+
+// The 9-grid anchors, mirroring the placement vocabulary of watermark-pdf.
+export const POSITIONS = [
+  'top-left',
+  'top-center',
+  'top-right',
+  'middle-left',
+  'center',
+  'middle-right',
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+]
+
+/** Fractional anchor (0..1) for a 9-grid position name. */
+function anchorOf(position) {
+  const [vertical, horizontal] = position.split('-')
+  const fx = horizontal === 'left' ? 0 : horizontal === 'right' ? 1 : 0.5
+  const fy = vertical === 'top' ? 0 : vertical === 'bottom' ? 1 : 0.5
+  return { fx, fy }
+}
+
+/**
+ * Top-left corner for a mark of `w`x`h` placed at `position` inside `cw`x`ch`,
+ * inset by `margin` so an edge-anchored mark isn't flush against the border.
+ */
+export function placeAt(position, cw, ch, w, h, margin) {
+  const { fx, fy } = anchorOf(position)
+  const x = margin + fx * (cw - w - margin * 2)
+  const y = margin + fy * (ch - h - margin * 2)
+  return { x, y }
+}
+
+/** Scale a logo to `scale` of the canvas width, preserving aspect ratio. */
+export function scaledLogoSize(logo, canvasWidth, scale) {
+  const src = dimsOf(logo)
+  const w = Math.max(1, canvasWidth * scale)
+  return { width: w, height: Math.max(1, (w * src.height) / src.width) }
+}
+
+/** Draw one mark repeatedly across the canvas, rotated, for the tiled layout. */
+function drawTiled(ctx, cw, ch, w, h, angle, draw) {
+  const stepX = w + Math.max(w * 0.5, 24)
+  const stepY = h + Math.max(h * 1.5, 24)
+  ctx.save()
+  ctx.translate(cw / 2, ch / 2)
+  ctx.rotate((angle * Math.PI) / 180)
+  // The rotated grid has to cover the diagonal, or corners come out bare.
+  const reach = Math.ceil(Math.hypot(cw, ch) / 2)
+  for (let y = -reach; y < reach; y += stepY) {
+    for (let x = -reach; x < reach; x += stepX) {
+      draw(x, y)
+    }
+  }
+  ctx.restore()
+}
+
+/**
+ * Composite a text or logo watermark onto one image.
+ *
+ * @param {File} file
+ * @param {{mode:'text'|'logo', text:string, logo:File|null, position:string,
+ *          layout:'single'|'tile', opacity:number, scale:number, color:string,
+ *          angle:number, quality:number}} opts
+ */
+export async function watermarkImage(file, opts, onProgress) {
+  const {
+    mode = 'text',
+    text = 'CONFIDENTIAL',
+    logo = null,
+    position = 'bottom-right',
+    layout = 'single',
+    opacity = 0.35,
+    scale = 0.25,
+    color = '#ffffff',
+    angle = 30,
+    quality = 0.92,
+  } = opts || {}
+
+  if (mode === 'text' && !text.trim()) throw new Error('Enter the watermark text.')
+  if (mode === 'logo' && !logo) throw new Error('Choose a logo image.')
+
+  onProgress?.(0.2, 'Decoding image…')
+  const bitmap = await decode(file)
+  const { width, height } = dimsOf(bitmap)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  ctx.drawImage(bitmap, 0, 0, width, height)
+
+  const margin = Math.round(Math.min(width, height) * 0.03)
+  ctx.globalAlpha = Math.min(Math.max(opacity, 0), 1)
+
+  if (mode === 'text') {
+    onProgress?.(0.6, 'Drawing text watermark…')
+    // Size the text off the canvas width so the result looks the same at any
+    // resolution, which is what makes batch output consistent.
+    const fontSize = Math.max(8, width * scale * 0.35)
+    ctx.font = `bold ${fontSize}px sans-serif`
+    ctx.textBaseline = 'top'
+    ctx.fillStyle = color
+    const metrics = ctx.measureText(text)
+    const w = metrics.width
+    const h = fontSize
+
+    if (layout === 'tile') {
+      drawTiled(ctx, width, height, w, h, angle, (x, y) => ctx.fillText(text, x, y))
+    } else {
+      const { x, y } = placeAt(position, width, height, w, h, margin)
+      ctx.fillText(text, x, y)
+    }
+  } else {
+    onProgress?.(0.6, 'Drawing logo watermark…')
+    const logoBitmap = await decode(logo)
+    const { width: w, height: h } = scaledLogoSize(logoBitmap, width, scale)
+
+    if (layout === 'tile') {
+      drawTiled(ctx, width, height, w, h, angle, (x, y) => ctx.drawImage(logoBitmap, x, y, w, h))
+    } else {
+      const { x, y } = placeAt(position, width, height, w, h, margin)
+      ctx.drawImage(logoBitmap, x, y, w, h)
+    }
+    logoBitmap.close?.()
+  }
+
+  ctx.globalAlpha = 1
+  onProgress?.(0.9, 'Encoding…')
+  const fmt = formatFromType(file.type)
+  const blob = await canvasToBlob(canvas, fmt, quality)
+  bitmap.close?.()
+  onProgress?.(1, 'Done')
+
+  return {
+    blob,
+    filename: outName(file.name, fmt, '-watermarked'),
+    before: file.size,
+    after: blob.size,
+  }
+}
+
+/** Watermark a batch, reporting progress across the whole set. */
+export async function watermarkImages(files, opts, onProgress) {
+  const results = []
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]
+    // Scale each file's own progress into its slice of the overall bar.
+    await watermarkImage(file, opts, (value, message) =>
+      onProgress?.((i + (value || 0)) / files.length, `${file.name}: ${message}`),
+    ).then((result) => results.push(result))
+  }
+  onProgress?.(1, 'Done')
+  return results
+}

--- a/src/operations/watermark-image/index.jsx
+++ b/src/operations/watermark-image/index.jsx
@@ -1,0 +1,204 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import ResultGallery from '../../components/ResultGallery.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes } from '../../lib/format.js'
+import { watermarkImages, POSITIONS } from './helpers.js'
+
+export default function WatermarkImage() {
+  const [files, setFiles] = useState([])
+  const [mode, setMode] = useState('text')
+  const [text, setText] = useState('CONFIDENTIAL')
+  const [logo, setLogo] = useState(null)
+  const [position, setPosition] = useState('bottom-right')
+  const [layout, setLayout] = useState('single')
+  const [opacity, setOpacity] = useState(0.35)
+  const [scale, setScale] = useState(0.25)
+  const [color, setColor] = useState('#ffffff')
+  const [angle, setAngle] = useState(30)
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const pick = (picked) => {
+    setFiles(picked)
+    reset()
+  }
+  const go = () =>
+    run((p) =>
+      watermarkImages(
+        files,
+        {
+          mode,
+          text,
+          logo,
+          position,
+          layout,
+          opacity: Number(opacity),
+          scale: Number(scale),
+          color,
+          angle: Number(angle),
+        },
+        p,
+      ),
+    )
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        accept="image/*"
+        multiple
+        label="Drop images here or click to browse"
+        hint="Watermark one image or a whole batch — all of them get the same mark"
+        icon="image"
+      />
+
+      {files.length > 0 && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="image" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+              {files.length === 1 ? files[0].name : `${files.length} images`}
+            </span>
+            <span className="text-xs text-slate-400">
+              {formatBytes(files.reduce((sum, f) => sum + f.size, 0))}
+            </span>
+          </div>
+
+          <div className="card space-y-4 p-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="space-y-1">
+                <span className="field-label">Watermark</span>
+                <select
+                  className="field-input"
+                  value={mode}
+                  onChange={(e) => setMode(e.target.value)}
+                >
+                  <option value="text">Text</option>
+                  <option value="logo">Logo image</option>
+                </select>
+              </label>
+
+              {mode === 'text' ? (
+                <label className="space-y-1">
+                  <span className="field-label">Text</span>
+                  <input
+                    className="field-input"
+                    value={text}
+                    onChange={(e) => setText(e.target.value)}
+                    placeholder="CONFIDENTIAL"
+                  />
+                </label>
+              ) : (
+                <label className="space-y-1">
+                  <span className="field-label">Logo</span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="field-input"
+                    onChange={(e) => {
+                      setLogo(e.target.files?.[0] || null)
+                      reset()
+                    }}
+                  />
+                </label>
+              )}
+
+              <label className="space-y-1">
+                <span className="field-label">Layout</span>
+                <select
+                  className="field-input"
+                  value={layout}
+                  onChange={(e) => setLayout(e.target.value)}
+                >
+                  <option value="single">Single placement</option>
+                  <option value="tile">Tiled across the image</option>
+                </select>
+              </label>
+
+              {layout === 'single' ? (
+                <label className="space-y-1">
+                  <span className="field-label">Position</span>
+                  <select
+                    className="field-input"
+                    value={position}
+                    onChange={(e) => setPosition(e.target.value)}
+                  >
+                    {POSITIONS.map((p) => (
+                      <option key={p} value={p}>
+                        {p.replace('-', ' ')}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : (
+                <label className="space-y-1">
+                  <span className="field-label">Angle: {angle}°</span>
+                  <input
+                    type="range"
+                    min="0"
+                    max="90"
+                    value={angle}
+                    onChange={(e) => setAngle(e.target.value)}
+                    className="w-full accent-brand-600"
+                  />
+                </label>
+              )}
+
+              <label className="space-y-1">
+                <span className="field-label">Opacity: {Math.round(opacity * 100)}%</span>
+                <input
+                  type="range"
+                  min="0.05"
+                  max="1"
+                  step="0.05"
+                  value={opacity}
+                  onChange={(e) => setOpacity(e.target.value)}
+                  className="w-full accent-brand-600"
+                />
+              </label>
+
+              <label className="space-y-1">
+                <span className="field-label">Size: {Math.round(scale * 100)}% of width</span>
+                <input
+                  type="range"
+                  min="0.05"
+                  max="1"
+                  step="0.05"
+                  value={scale}
+                  onChange={(e) => setScale(e.target.value)}
+                  className="w-full accent-brand-600"
+                />
+              </label>
+
+              {mode === 'text' && (
+                <label className="space-y-1">
+                  <span className="field-label">Color</span>
+                  <input
+                    type="color"
+                    value={color}
+                    onChange={(e) => setColor(e.target.value)}
+                    className="field-input h-10 p-1"
+                  />
+                </label>
+              )}
+            </div>
+          </div>
+
+          <button type="button" className="btn-primary" onClick={go} disabled={running}>
+            <Icon name="droplet" className="h-4 w-4" />
+            {files.length > 1 ? `Watermark ${files.length} images` : 'Add watermark'}
+          </button>
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && <Note type="error" title="Watermark failed">{error}</Note>}
+      {result && !running && (
+        <ResultGallery results={result} zipName="doxdock-watermarked.zip" />
+      )}
+    </div>
+  )
+}

--- a/src/operations/watermark-image/meta.js
+++ b/src/operations/watermark-image/meta.js
@@ -1,0 +1,10 @@
+export default {
+  id: 'watermark-image',
+  name: 'Watermark Image',
+  description: 'Overlay text or a logo — position, opacity and size, single or tiled.',
+  category: 'image',
+  icon: 'droplet',
+  order: 26,
+  notes:
+    'Compositing happens on a canvas in your browser, so nothing is uploaded. Re-encoding also drops any EXIF/GPS metadata the original carried. Drop several images to watermark them all at once.',
+}


### PR DESCRIPTION
Adds a `watermark-image` operation: text or a logo, 9-grid placement or tiled, with opacity and size.

Follows the plugin pattern — self-contained `src/operations/watermark-image/{meta.js,index.jsx,helpers.js}`, auto-discovered with no central wiring, reusing `Dropzone`, `useJob`, `Note`, `Progress`, `Icon`, `ResultGallery` and `lib/imageCanvas`. Placement vocabulary is carried over from `watermark-pdf`.

## Options
- **Text or logo** — type a string, or upload an image to overlay.
- **Position** — the 9-grid (`top-left` … `bottom-right`), or **tiled** across the whole image.
- **Opacity** — 5–100%.
- **Size** — as a fraction of the image width, not absolute pixels. That's deliberate: a batch of mixed-resolution photos then gets a *visually* consistent mark instead of one that's huge on a thumbnail and invisible on a 4000px original.
- **Color** for text.

## Batch
`watermarkImages` runs the set and scales each file's own progress into its slice of the overall bar, so the progress message reads `b.png: Drawing text watermark…` rather than jumping. Results land in `ResultGallery`, which already gives per-file download plus **Download all (.zip)**.

## Verification

Ran it against solid-black generated PNGs so any watermark pixel is unambiguous, and measured the output pixels rather than eyeballing it.

**Placement** — counting non-black pixels per quadrant on a 400×300 source:

| setting | tl | tr | bl | br |
|---|---|---|---|---|
| `top-left` | 2676 | 913 | 0 | 0 |
| `bottom-right` (default) | 0 | 0 | 919 | 2658 |
| `center` | 1114 | 988 | 714 | 677 |
| `tile` | 4948 | 1330 | 4169 | 2207 |

Placement lands where it says, and tiling covers ~3.5× the area of a single mark across all four quadrants.

**Opacity** — with `opacity: 0.35` on pure black, the brightest output pixel is **89**, i.e. `255 × 0.35 = 89.25`. Applied exactly, not approximately.

**Batch** — dropped two images (400×300 and 320×240), got `a-watermarked.png` and `b-watermarked.png` plus the zip action; each output keeps its **own** source dimensions, so nothing is resized.

**Offline** — the network log during a full run shows only `localhost` requests. No CDN, no external asset, nothing added to `package.json`; compositing is plain canvas. Respects the `connect-src 'self'` CSP.

No console errors from the operation.

Small aside: while testing I initially dropped two byte-identical images and only one registered — that's the `dedupeFiles` name+size check doing its job, not a bug here.
