### PR TITLE
compress-image: never produce a larger file than the source

### DIFF
--- a/src/operations/compress-image/helpers.js
+++ b/src/operations/compress-image/helpers.js
@@ -19,10 +19,15 @@ export async function compressImage(file, opts, onProgress) {
   if (maxDimension) options.maxWidthOrHeight = Number(maxDimension)
   if (format !== 'keep') options.fileType = MIME[format]
 
+  const outType = options.fileType || file.type
   const out = await imageCompression(file, options)
   const ext = format === 'keep' ? file.name.split('.').pop() : format === 'jpeg' ? 'jpg' : format
   const base = file.name.replace(/\.[^.]+$/, '')
-  const blob = out instanceof Blob ? out : new Blob([out], { type: options.fileType || file.type })
+  let blob = out instanceof Blob ? out : new Blob([out], { type: outType })
+  // Re-encoding a lossless format (e.g. PNG) can yield a LARGER file than the source. When we didn't
+  // change the format and couldn't actually shrink it, keep the original bytes so "compress" never inflates.
+  // A genuine format change (e.g. JPEG -> PNG) is left as-is, since the larger size is inherent to it.
+  if (outType === file.type && blob.size >= file.size) blob = file
   return {
     blob,
     filename: `${base}-compressed.${ext}`,


### PR DESCRIPTION
Fixes #105.

PNG is lossless, so re-encoding it through the compressor can produce a **larger** file than the source (the `initialQuality` knob does nothing for PNG). The tool then reports a "compressed" file bigger than the original.

Fix: after compression, if the output format is the **same** as the source and the result isn't actually smaller, keep the original bytes. That guarantees "Compress Image" never inflates a file. A genuine format change (e.g. JPEG → PNG) is left untouched, since a size increase there is inherent to the target format.

Verified `npm run build` passes. (No unit-test harness in the repo; the guard is a size comparison on the produced blob.)
