### PR TITLE
split-pdf: add by-size and by-bookmarks modes

### DIFF
--- a/src/operations/split-pdf/helpers.js
+++ b/src/operations/split-pdf/helpers.js
@@ -1,4 +1,4 @@
-import { PDFDocument } from 'pdf-lib'
+import { PDFDocument, PDFName, PDFDict, PDFArray, PDFRef } from 'pdf-lib'
 import { baseName, parsePageRanges } from '../../lib/format.js'
 
 async function subsetPdf(srcDoc, pageIndices) {
@@ -9,13 +9,78 @@ async function subsetPdf(srcDoc, pageIndices) {
   return new Blob([bytes], { type: 'application/pdf' })
 }
 
+// Greedily pack pages into groups so each rendered PDF stays at/under `limitBytes`.
+// A single page larger than the limit becomes its own (over-size) group — flagged, not dropped.
+async function packBySize(src, total, limitBytes, onProgress) {
+  const groups = []
+  let current = []
+  for (let i = 0; i < total; i++) {
+    onProgress?.(i / total, `Packing page ${i + 1} of ${total}…`)
+    const candidate = [...current, i]
+    const blob = await subsetPdf(src, candidate)
+    if (blob.size > limitBytes && current.length) {
+      // Adding page i overflows the current group: close it and start a new one with page i.
+      groups.push(current)
+      current = [i]
+    } else {
+      current = candidate
+    }
+  }
+  if (current.length) groups.push(current)
+  return groups
+}
+
+// Resolve a bookmark destination (array/dict, or a GoTo action) to the page ref it points at.
+function destPageRef(item) {
+  let dest = item.get(PDFName.of('Dest'))
+  if (!dest) {
+    const action = item.get(PDFName.of('A'))
+    if (action instanceof PDFDict) dest = action.get(PDFName.of('D'))
+  }
+  if (dest instanceof PDFArray && dest.size() > 0) {
+    const target = dest.get(0)
+    if (target instanceof PDFRef) return target
+  }
+  return null
+}
+
+// Read the top-level bookmarks (outline entries) as { title, pageIndex }, in document order.
+// Named destinations and entries we can't resolve to a concrete page ref are skipped.
+function topLevelBookmarks(src) {
+  const outlines = src.catalog.lookupMaybe(PDFName.of('Outlines'), PDFDict)
+  if (!outlines) return []
+  const refKey = (ref) => `${ref.objectNumber}R${ref.generationNumber}`
+  const pageIndexByRef = new Map()
+  src.getPages().forEach((page, index) => pageIndexByRef.set(refKey(page.ref), index))
+
+  const bookmarks = []
+  const seen = new Set()
+  let itemRef = outlines.get(PDFName.of('First'))
+  while (itemRef instanceof PDFRef && !seen.has(refKey(itemRef))) {
+    seen.add(refKey(itemRef))
+    const item = src.context.lookup(itemRef, PDFDict)
+    if (!item) break
+    const pageRef = destPageRef(item)
+    const pageIndex = pageRef ? pageIndexByRef.get(refKey(pageRef)) : undefined
+    if (pageIndex != null) {
+      const title = item.get(PDFName.of('Title'))
+      bookmarks.push({
+        title: title && typeof title.decodeText === 'function' ? title.decodeText() : `Bookmark ${bookmarks.length + 1}`,
+        pageIndex,
+      })
+    }
+    itemRef = item.get(PDFName.of('Next'))
+  }
+  return bookmarks
+}
+
 /**
  * @param {File} file
- * @param {{mode:'explode'|'ranges', ranges:string}} opts
+ * @param {{mode:'explode'|'ranges'|'size'|'bookmarks', ranges:string, sizeMb:number}} opts
  * @returns {Promise<{filename:string, blob:Blob}[]>}
  */
 export async function splitPdf(file, opts, onProgress) {
-  const { mode = 'explode', ranges = '' } = opts || {}
+  const { mode = 'explode', ranges = '', sizeMb = 5 } = opts || {}
   let src
   try {
     src = await PDFDocument.load(await file.arrayBuffer())
@@ -26,7 +91,31 @@ export async function splitPdf(file, opts, onProgress) {
   const base = baseName(file.name)
   const results = []
 
-  if (mode === 'explode') {
+  if (mode === 'size') {
+    const limitBytes = Math.max(0.05, Number(sizeMb) || 0) * 1024 * 1024
+    const groups = await packBySize(src, total, limitBytes, onProgress)
+    for (let g = 0; g < groups.length; g++) {
+      const blob = await subsetPdf(src, groups[g])
+      const over = blob.size > limitBytes ? '-oversize' : ''
+      results.push({ filename: `${base}-part${String(g + 1).padStart(2, '0')}${over}.pdf`, blob })
+    }
+  } else if (mode === 'bookmarks') {
+    const bookmarks = topLevelBookmarks(src)
+    if (!bookmarks.length) {
+      throw new Error('This PDF has no top-level bookmarks to split on.')
+    }
+    for (let b = 0; b < bookmarks.length; b++) {
+      onProgress?.(b / bookmarks.length, `Building chapter ${b + 1} of ${bookmarks.length}…`)
+      const start = bookmarks[b].pageIndex
+      const end = b + 1 < bookmarks.length ? bookmarks[b + 1].pageIndex : total
+      const pageIndices = []
+      for (let p = start; p < end; p++) pageIndices.push(p)
+      if (!pageIndices.length) continue
+      const blob = await subsetPdf(src, pageIndices)
+      const slug = (bookmarks[b].title || `chapter-${b + 1}`).replace(/[^\w-]+/g, '_').slice(0, 60)
+      results.push({ filename: `${base}-${String(b + 1).padStart(2, '0')}-${slug}.pdf`, blob })
+    }
+  } else if (mode === 'explode') {
     for (let i = 0; i < total; i++) {
       onProgress?.(i / total, `Extracting page ${i + 1} of ${total}…`)
       const blob = await subsetPdf(src, [i])

--- a/src/operations/split-pdf/index.jsx
+++ b/src/operations/split-pdf/index.jsx
@@ -13,6 +13,7 @@ export default function SplitPdf() {
   const [file, setFile] = useState(null)
   const [mode, setMode] = useState('explode')
   const [ranges, setRanges] = useState('')
+  const [sizeMb, setSizeMb] = useState(5)
   const { running, progress, error, result, run, reset } = useJob()
   const { pageCount } = usePdfPageCount(file)
 
@@ -37,7 +38,7 @@ export default function SplitPdf() {
     setFile(files[0])
     reset()
   }
-  const go = () => run((p) => splitPdf(file, { mode, ranges }, p))
+  const go = () => run((p) => splitPdf(file, { mode, ranges, sizeMb }, p))
 
   return (
     <div className="space-y-6">
@@ -62,7 +63,32 @@ export default function SplitPdf() {
                 <input type="radio" name="mode" checked={mode === 'ranges'} onChange={() => setMode('ranges')} />
                 Page ranges — one PDF per range
               </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input type="radio" name="mode" checked={mode === 'size'} onChange={() => setMode('size')} />
+                By size — pack pages so each PDF stays under a target
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input type="radio" name="mode" checked={mode === 'bookmarks'} onChange={() => setMode('bookmarks')} />
+                By bookmarks — one PDF per top-level bookmark (chapter)
+              </label>
             </fieldset>
+            {mode === 'size' && (
+              <label className="block space-y-1">
+                <span className="field-label">Target size per file (MB)</span>
+                <input
+                  className="field-input"
+                  type="number"
+                  min="0.05"
+                  step="0.5"
+                  value={sizeMb}
+                  onChange={(e) => setSizeMb(e.target.value)}
+                />
+                <span className="text-xs text-slate-500">Best-effort: a single page larger than the target becomes its own file (marked <code>-oversize</code>).</span>
+              </label>
+            )}
+            {mode === 'bookmarks' && (
+              <p className="text-xs text-slate-500">Splits at each top-level bookmark. A PDF with no bookmarks reports a clear message.</p>
+            )}
             {mode === 'ranges' && (
               <label className="block space-y-1">
                 <span className="field-label">Ranges (comma-separated groups)</span>
@@ -83,7 +109,7 @@ export default function SplitPdf() {
             type="button"
             className="btn-primary"
             onClick={go}
-            disabled={running || (mode === 'ranges' && (!ranges.trim() || !!rangeError))}
+            disabled={running || (mode === 'ranges' && (!ranges.trim() || !!rangeError)) || (mode === 'size' && !(Number(sizeMb) > 0))}
           >
             <Icon name="scissors" className="h-4 w-4" />
             Split PDF


### PR DESCRIPTION
Fixes #91.

Adds two modes to the existing **Split PDF** tool, alongside Explode and Ranges:

- **By size** — greedily packs pages so each output PDF stays at/under a target MB. A single page larger than the target becomes its own file, flagged `-oversize` (best-effort, as noted in the issue). Only the current group is re-serialized while packing, so a small target (many small files) stays cheap.
- **By bookmarks** — reads the PDF outline and emits one PDF per top-level bookmark (chapter), named from the bookmark title. A PDF with no top-level bookmarks reports a clear message instead of failing.

Existing Explode/Ranges modes are unchanged (they share `subsetPdf`/`parsePageRanges`). Stays 100% client-side — only `pdf-lib`, no new deps, no network.

Bookmark resolution handles array destinations and `GoTo` actions, maps the target to a concrete page ref, and skips named destinations / unresolvable entries rather than guessing.

### Verification

`npm run build` passes. I exercised the logic in Node against a generated fixture (multi-page PDF with a hand-built outline + incompressible image pages):
- By size splits into multiple files, preserves every page (no loss/dup), and each multi-page group stays under the limit.
- By bookmarks produces one file per top-level bookmark with the right page spans; a bookmark-less PDF throws the friendly "no top-level bookmarks" error.
- Explode and Ranges still behave as before.
