### PR TITLE
feat: show a live character count for Markdown → PDF and HTML → PDF input

### DIFF
--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -21,6 +21,12 @@ export function percentChange(before, after) {
   return Math.round(((before - after) / before) * 100)
 }
 
+/** Character count for a text input: "0 characters", "1 character", "1,234 characters". */
+export function formatCharCount(text) {
+  const n = String(text ?? '').length
+  return `${n.toLocaleString()} ${n === 1 ? 'character' : 'characters'}`
+}
+
 /** Strip the extension from a filename: "a.b.pdf" -> "a.b". */
 export function baseName(name = '') {
   const dot = name.lastIndexOf('.')

--- a/src/operations/html-to-pdf/index.jsx
+++ b/src/operations/html-to-pdf/index.jsx
@@ -4,6 +4,7 @@ import Note from '../../components/Note.jsx'
 import Icon from '../../components/Icon.jsx'
 import DownloadButton from '../../components/DownloadButton.jsx'
 import { useJob } from '../../hooks/useJob.js'
+import { formatCharCount } from '../../lib/format.js'
 import { htmlToPdf } from './helpers.js'
 
 const SAMPLE = `<h1>DoxDock</h1>
@@ -50,6 +51,9 @@ export default function HtmlToPdf() {
           className="field-input h-72 font-mono text-sm leading-relaxed"
           spellCheck={false}
         />
+        <span className="block text-right text-xs text-slate-500 dark:text-slate-400" aria-live="polite">
+          {formatCharCount(text)}
+        </span>
       </label>
 
       <div className="card p-4">

--- a/src/operations/markdown-to-pdf/index.jsx
+++ b/src/operations/markdown-to-pdf/index.jsx
@@ -4,6 +4,7 @@ import Note from '../../components/Note.jsx'
 import Icon from '../../components/Icon.jsx'
 import DownloadButton from '../../components/DownloadButton.jsx'
 import { useJob } from '../../hooks/useJob.js'
+import { formatCharCount } from '../../lib/format.js'
 import { markdownToPdf } from './helpers.js'
 
 const SAMPLE = `# DoxDock
@@ -60,6 +61,9 @@ export default function MarkdownToPdf() {
           className="field-input h-72 font-mono text-sm leading-relaxed"
           spellCheck={false}
         />
+        <span className="block text-right text-xs text-slate-500 dark:text-slate-400" aria-live="polite">
+          {formatCharCount(text)}
+        </span>
       </label>
 
       <div className="card p-4">


### PR DESCRIPTION
Closes #18.

## Change

A live `N characters` counter under the textarea in both **Markdown → PDF** and **HTML → PDF**.

The formatting helper goes in `src/lib/format.js`, next to `formatBytes` — same job, same home, and it keeps the two tool files from carrying a duplicated copy of the pluralisation rule:

```js
/** Character count for a text input: "0 characters", "1 character", "1,234 characters". */
export function formatCharCount(text) {
  const n = String(text ?? '').length
  return `${n.toLocaleString()} ${n === 1 ? 'character' : 'characters'}`
}
```

Two small touches beyond the literal ask:

- **`toLocaleString`** so a long document reads `12,480 characters` instead of a wall of digits, and correct **pluralisation** at 1.
- **`aria-live="polite"`** on the counter, so a screen-reader user hears the count change without focus being stolen mid-typing.

The count derives from the same `text` state the textarea is already bound to, so it updates on every keystroke with no extra state, no effect and no re-render beyond the one React already does.

## Verified in the running app

`npm run dev`, driving the real components (not a harness). Markdown → PDF:

| input | counter |
|---|---|
| empty | `0 characters` |
| one typed key | `1 character` |
| "Insert sample" (253 chars) | `253 characters` |
| 1234 chars | `1,234 characters` |
| cleared again | `0 characters` |

The single-character case was typed through the real keyboard path; the rest were driven through React's `onChange`. HTML → PDF behaves identically (`0 characters` → `11 characters` for `<h1>hi</h1>`).

`npm run build` succeeds (27 tool pages prerendered). No new console errors — the only ones present are the pre-existing `frame-ancestors` CSP-in-meta warnings, which are on `main` too.

## Notes

Nothing leaves the browser; this is a pure `.length` read on state that already exists. No new dependency, no network, no CSP impact.

While checking the tracker I noticed **#94 (watermark an image)** looks already satisfied on `main` — `src/operations/watermark-image/` exists and is wired up — so it may just need closing.
