### PR TITLE
feat: warn when a selected file is very large

### DIFF
--- a/src/components/Dropzone.jsx
+++ b/src/components/Dropzone.jsx
@@ -1,13 +1,27 @@
 import { useRef, useState, useCallback, useId } from 'react'
 import Icon from './Icon.jsx'
-import { cx } from '../lib/format.js'
+import Note from './Note.jsx'
+import { cx, formatBytes } from '../lib/format.js'
 import { useFileDrop } from '../hooks/useFileDrop.js'
+
+// Past this, a browser-side job is slow enough (and memory-hungry enough) to be
+// worth a heads-up before the user waits on it. Advisory only — nothing here
+// blocks or rejects a file.
+const LARGE_FILE_BYTES = 100 * 1024 * 1024 // ~100 MB
+
+const asArray = (value) => (value == null ? [] : Array.isArray(value) ? value : [value])
 
 // Reusable drag-and-drop dropzone + file picker. Keyboard accessible (Enter/Space
 // opens the picker). Files never leave the browser — they are handed straight to
 // the calling operation.
+//
+// `files` is optional: pass the operation's own selection when it can be cleared
+// or items removed, so the large-file heads-up tracks it exactly. Left out, the
+// heads-up reflects the most recent pick, which is right for the single-file
+// tools that simply replace their selection.
 export default function Dropzone({
   onFiles,
+  files,
   accept,
   multiple = true,
   label = 'Drop files here or click to browse',
@@ -16,12 +30,19 @@ export default function Dropzone({
 }) {
   const inputRef = useRef(null)
   const [dragging, setDragging] = useState(false)
+  const [picked, setPicked] = useState([])
   const id = useId()
+
+  const selected = files === undefined ? picked : asArray(files)
+  const oversized = selected.filter((f) => f && f.size > LARGE_FILE_BYTES)
 
   const handleFiles = useCallback(
     (fileList) => {
       const files = Array.from(fileList || [])
-      if (files.length) onFiles(multiple ? files : [files[0]])
+      if (!files.length) return
+      const chosen = multiple ? files : [files[0]]
+      setPicked(chosen)
+      onFiles(chosen)
     },
     [onFiles, multiple],
   )
@@ -45,6 +66,7 @@ export default function Dropzone({
   useFileDrop(onWindowFileDrop)
 
   return (
+    <>
     <div
       role="button"
       tabIndex={0}
@@ -101,5 +123,20 @@ export default function Dropzone({
         }}
       />
     </div>
+    {oversized.length > 0 && (
+      <Note type="warning" title="Large file — this may take a while" className="mt-3">
+        {oversized.length === 1 ? (
+          <>
+            <span className="font-medium">{oversized[0].name}</span> is{' '}
+            {formatBytes(oversized[0].size)}.
+          </>
+        ) : (
+          <>{oversized.length} of the selected files are over {formatBytes(LARGE_FILE_BYTES)}.</>
+        )}{' '}
+        Everything still runs locally in this tab, so expect a slower job and higher memory use —
+        and keep the tab open until it finishes. You can carry on regardless.
+      </Note>
+    )}
+    </>
   )
 }

--- a/src/operations/images-to-pdf/index.jsx
+++ b/src/operations/images-to-pdf/index.jsx
@@ -44,6 +44,7 @@ export default function ImagesToPdf() {
     <div className="space-y-6">
       <Dropzone
         onFiles={addFiles}
+        files={files}
         accept="image/*"
         label="Drop images here or click to browse"
         hint="JPEG, PNG, WebP, GIF, BMP — reorder them below after adding"

--- a/src/operations/merge-pdfs/index.jsx
+++ b/src/operations/merge-pdfs/index.jsx
@@ -33,7 +33,7 @@ export default function MergePdfs() {
 
   return (
     <div className="space-y-6">
-      <Dropzone onFiles={add} accept="application/pdf,.pdf" label="Drop PDFs here or click to browse" hint="Add two or more PDFs, then drag to reorder" icon="fileText" />
+      <Dropzone onFiles={add} files={files} accept="application/pdf,.pdf" label="Drop PDFs here or click to browse" hint="Add two or more PDFs, then drag to reorder" icon="fileText" />
 
       {files.length > 0 && (
         <>


### PR DESCRIPTION
Closes #17.

## Where it lives

`Dropzone` is the single funnel every file selection goes through — the click-to-browse input, a drop on the box, and the window-wide drop handler in `useFileDrop`. Putting the check there means all 25 tools get the heads-up from one place, instead of 25 copies of the same threshold drifting apart.

```js
const LARGE_FILE_BYTES = 100 * 1024 * 1024 // ~100 MB
```

The `Note` renders as a sibling below the dropzone box, not inside it — the box is `role="button"` and opens the picker on click, so a note nested in it would be a click target.

## Non-blocking, and it says so

Nothing is rejected, no button is disabled, and the copy reflects that ("You can carry on regardless"). The reason for the warning is the honest one for a client-side tool: the work happens in this tab, so a big file means a slower job, more memory, and don't close the tab. Size comes from `File.size`, which is already in memory — no file is read to produce it.

## Keeping it in sync with the selection

`Dropzone` tracks its own last pick, which is exactly right for the single-file tools: they replace their selection, so replacing a 150 MB file with a small one clears the note.

The two multi-file tools (`merge-pdfs`, `images-to-pdf`) can also remove individual items and "Clear all", and last-pick state would go stale there — the note would linger after the list was emptied. Rather than leave that edge, `Dropzone` takes an optional `files` prop; when the operation passes its own array, the note is derived from that state directly. Two call sites, one prop each.

## Verified in the running app

`npm run dev`, driving the real components:

**Compress PDF (single-file, no `files` prop):**

| action | result |
|---|---|
| pick a 1 KB PDF | no note |
| pick a 150 MB PDF | note: *"Large file — this may take a while. **huge-scan.pdf** is 150.0 MB…"* |
| — same moment | "Compress" button still enabled (`disabled === false`) |
| replace with a 2 KB PDF | note gone, new file shown |

**Merge PDFs (multi-file, `files` prop):**

| action | result |
|---|---|
| add 120 MB + 200 MB + 5 KB | note: *"2 of the selected files are over 100.0 MB…"* — counts only the oversized ones |
| click "Clear all" | note gone |

`npm run build` succeeds (27 tool pages prerendered). No new console errors; the only ones present are the pre-existing `frame-ancestors` CSP-in-meta warnings, also on `main`.

## Notes

The threshold is a single named constant, so it is one edit if ~100 MB turns out to be the wrong line. Sizes render through the existing `formatBytes`, so the note reads "150.0 MB" in the same units as the rest of the UI.
