### PR TITLE
feat: accept an image pasted from the clipboard

### DIFF
--- a/src/components/Dropzone.jsx
+++ b/src/components/Dropzone.jsx
@@ -2,10 +2,11 @@ import { useRef, useState, useCallback, useId } from 'react'
 import Icon from './Icon.jsx'
 import { cx } from '../lib/format.js'
 import { useFileDrop } from '../hooks/useFileDrop.js'
+import { usePasteFiles } from '../hooks/usePasteFiles.js'
 
-// Reusable drag-and-drop dropzone + file picker. Keyboard accessible (Enter/Space
-// opens the picker). Files never leave the browser — they are handed straight to
-// the calling operation.
+// Reusable drag-and-drop dropzone + file picker, also accepting a clipboard
+// paste. Keyboard accessible (Enter/Space opens the picker). Files never leave
+// the browser — they are handed straight to the calling operation.
 export default function Dropzone({
   onFiles,
   accept,
@@ -43,6 +44,9 @@ export default function Dropzone({
     [handleFiles],
   )
   useFileDrop(onWindowFileDrop)
+
+  // Same for a clipboard paste, filtered by this tool's `accept`.
+  usePasteFiles(handleFiles, accept)
 
   return (
     <div
@@ -83,6 +87,9 @@ export default function Dropzone({
       </span>
       <div>
         <p className="font-medium text-slate-700 dark:text-slate-200">{label}</p>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          …or paste one from the clipboard
+        </p>
         {hint && (
           <p id={`${id}-hint`} className="mt-1 text-sm text-slate-500 dark:text-slate-400">
             {hint}

--- a/src/hooks/usePasteFiles.js
+++ b/src/hooks/usePasteFiles.js
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { matchesAccept } from '../lib/accept.js'
+
+// Route files carried on the clipboard into the same pipeline as the picker and
+// drag-and-drop. A screenshot lands on the clipboard as a file item, so this is
+// the shortest path from "grab a screenshot" to "convert it" — no saving to
+// disk and re-picking. Purely local: the File already exists in the page,
+// nothing is read or sent anywhere.
+//
+// `accept` applies the filter the native picker would have applied, since the
+// clipboard offers no such guarantee. The paste is only claimed
+// (preventDefault) when a file actually matches, so pasting text into a field,
+// or pasting a screenshot into a PDF-only tool, behaves exactly as before.
+export function usePasteFiles(onFiles, accept) {
+  useEffect(() => {
+    const onPaste = (event) => {
+      const files = Array.from(event.clipboardData?.items || [])
+        .filter((item) => item.kind === 'file')
+        .map((item) => item.getAsFile())
+        .filter((file) => file && matchesAccept(file, accept))
+      if (!files.length) return
+      event.preventDefault()
+      onFiles(files)
+    }
+
+    window.addEventListener('paste', onPaste)
+    return () => window.removeEventListener('paste', onPaste)
+  }, [onFiles, accept])
+}

--- a/src/lib/accept.js
+++ b/src/lib/accept.js
@@ -1,0 +1,26 @@
+// Match a File against an <input accept> string, so sources that bypass the
+// native picker (clipboard paste, window-wide drops) can apply the same filter
+// the picker would have.
+
+/**
+ * Does `file` satisfy `accept`? An empty/absent accept means "anything".
+ * Handles the three token forms the tools use: ".png" extensions,
+ * "image/*" wildcards, and exact types like "application/pdf".
+ */
+export function matchesAccept(file, accept) {
+  if (!file) return false
+  const tokens = String(accept || '')
+    .split(',')
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean)
+  if (!tokens.length) return true
+
+  const type = (file.type || '').toLowerCase()
+  const name = (file.name || '').toLowerCase()
+
+  return tokens.some((token) => {
+    if (token.startsWith('.')) return name.endsWith(token)
+    if (token.endsWith('/*')) return type.startsWith(token.slice(0, -1))
+    return type === token
+  })
+}


### PR DESCRIPTION
Closes #5.

## Change

`usePasteFiles` — a window-level `paste` listener that pulls file items off the clipboard and hands them to the **same** `handleFiles` the picker and drag-and-drop already use. It's wired into `Dropzone`, so every file-taking tool gets it from one place, including Images → PDF and the image tools the issue names.

Two new files, both small:

- `src/hooks/usePasteFiles.js` — the listener.
- `src/lib/accept.js` — `matchesAccept(file, accept)`, matching a `File` against an `<input accept>` string.

`Dropzone` gains two lines.

## Why `accept` matters here

The native picker enforces `accept` for us; the clipboard offers no such guarantee. Without a filter, pasting a screenshot while Merge PDFs is open would hand `pdf-lib` a PNG. `matchesAccept` applies the same rule the picker would, handling the three token forms the tools actually use — `.docx` extensions, `image/*` wildcards, and exact types like `application/pdf` — case-insensitively, and falling back to the extension when the clipboard supplies no MIME type.

The paste is claimed with `preventDefault()` **only after** a file has matched. So pasting text into a field, or pasting a screenshot into a tool that can't use it, is left entirely alone rather than being silently swallowed.

## Discoverability

The dropzone now reads "…or paste one from the clipboard" under its label. A hidden shortcut nobody knows about isn't a feature; this is one line in the shared component rather than 25 edited labels.

## Verified in the running app

`npm run dev`, dispatching real `ClipboardEvent`s carrying a real PNG produced from a canvas — the same shape a screenshot arrives in.

**Images → PDF:**

| paste | claimed | result |
|---|---|---|
| `screenshot.png` | yes | file list shows `screenshot.png`, "1 file selected" |

**Merge PDFs (`accept="application/pdf,.pdf"`):**

| paste | claimed | added |
|---|---|---|
| a PNG | **no** | no — correctly ignored, event left alone |
| plain text | **no** | n/a |
| `doc.pdf` | yes | yes |

`matchesAccept` checked against all eight combinations the repo's `accept` strings produce (wildcard hit/miss, exact type, extension fallback with empty MIME, `.docx`, uppercase `.MD`, empty accept, non-matching type) — all correct.

## No network

Verified in the network panel: the only requests during the whole exercise are Vite's local module fetches. The `File` already exists in the page; nothing reads or transmits it, and no new dependency is added, so the strict CSP is untouched.

I could not run `npm run test:e2e` here — `@playwright/test` isn't present in this clone's `node_modules` and installing the browsers wasn't practical on this machine. `npm run build` passes (27 tool pages prerendered), and the network-isolation assertion that spec makes is what I checked by hand above.
