### PR TITLE
feat: add AVIF support to Convert Image

### DIFF
--- a/src/lib/imageCanvas.js
+++ b/src/lib/imageCanvas.js
@@ -3,13 +3,24 @@
 // strips EXIF/GPS metadata (canvas output contains no metadata).
 
 const MIME = {
+  avif: 'image/avif',
   jpeg: 'image/jpeg',
   jpg: 'image/jpeg',
   png: 'image/png',
   webp: 'image/webp',
 }
 
-export const FORMAT_EXT = { jpeg: 'jpg', png: 'png', webp: 'webp' }
+export const FORMAT_EXT = { avif: 'avif', jpeg: 'jpg', png: 'png', webp: 'webp' }
+
+/** Detect whether the browser can encode the given MIME type. */
+export function canEncode(mime) {
+  const canvas = document.createElement('canvas')
+  canvas.width = 2
+  canvas.height = 2
+  const ctx = canvas.getContext('2d')
+  ctx.fillRect(0, 0, 2, 2)
+  return canvas.toDataURL(mime).startsWith(`data:${mime}`)
+}
 
 /** Decode a File/Blob into an ImageBitmap (with a fallback to <img>). */
 export async function decode(file) {
@@ -37,7 +48,7 @@ export function dimsOf(bitmap) {
   return { width: bitmap.width || bitmap.naturalWidth, height: bitmap.height || bitmap.naturalHeight }
 }
 
-/** Encode a canvas to a Blob of the given format ('jpeg'|'png'|'webp'). */
+/** Encode a canvas to a Blob of the given format ('avif'|'jpeg'|'png'|'webp'). */
 export function canvasToBlob(canvas, format = 'jpeg', quality = 0.9) {
   const mime = MIME[format] || 'image/jpeg'
   return new Promise((resolve, reject) => {

--- a/src/lib/imageFormat.js
+++ b/src/lib/imageFormat.js
@@ -1,13 +1,14 @@
 // Shared helpers for the image operations: map MIME types to format keys and
 // build output filenames.
 export function formatFromType(type = '') {
+  if (/avif/i.test(type)) return 'avif'
   if (/jpe?g/i.test(type)) return 'jpeg'
   if (/png/i.test(type)) return 'png'
   if (/webp/i.test(type)) return 'webp'
   return 'jpeg'
 }
 
-export const EXT = { jpeg: 'jpg', png: 'png', webp: 'webp' }
+export const EXT = { avif: 'avif', jpeg: 'jpg', png: 'png', webp: 'webp' }
 
 export function outName(originalName, format, suffix = '') {
   const base = originalName.replace(/\.[^.]+$/, '')

--- a/src/operations/convert-image/helpers.js
+++ b/src/operations/convert-image/helpers.js
@@ -1,12 +1,15 @@
-import { decode, drawToCanvas, canvasToBlob } from '../../lib/imageCanvas.js'
+import { decode, drawToCanvas, canvasToBlob, canEncode } from '../../lib/imageCanvas.js'
 import { outName } from '../../lib/imageFormat.js'
 
 /**
  * @param {File} file
- * @param {{format:'jpeg'|'png'|'webp', quality:number}} opts
+ * @param {{format:'avif'|'jpeg'|'png'|'webp', quality:number}} opts
  */
 export async function convertImage(file, opts, onProgress) {
   const { format = 'png', quality = 0.9 } = opts || {}
+  if (format === 'avif' && !canEncode('image/avif')) {
+    throw new Error('This browser cannot encode AVIF. Try JPEG, PNG, or WebP.')
+  }
   onProgress?.(0.3, 'Decoding image…')
   const bitmap = await decode(file)
   onProgress?.(0.6, `Encoding ${format.toUpperCase()}…`)

--- a/src/operations/convert-image/index.jsx
+++ b/src/operations/convert-image/index.jsx
@@ -6,6 +6,7 @@ import Icon from '../../components/Icon.jsx'
 import ImageResult from '../../components/ImageResult.jsx'
 import { useJob } from '../../hooks/useJob.js'
 import { formatBytes } from '../../lib/format.js'
+import { canEncode } from '../../lib/imageCanvas.js'
 import { convertImage } from './helpers.js'
 
 export default function ConvertImage() {
@@ -13,6 +14,7 @@ export default function ConvertImage() {
   const [format, setFormat] = useState('png')
   const [quality, setQuality] = useState(0.9)
   const { running, progress, error, result, run, reset } = useJob()
+  const [avifSupported] = useState(() => canEncode('image/avif'))
 
   const pick = (files) => {
     setFile(files[0])
@@ -40,7 +42,13 @@ export default function ConvertImage() {
                   <option value="png">PNG</option>
                   <option value="jpeg">JPEG</option>
                   <option value="webp">WebP</option>
+                  <option value="avif" disabled={!avifSupported}>
+                    AVIF{avifSupported ? '' : ' (unsupported in this browser)'}
+                  </option>
                 </select>
+                {format === 'avif' && !avifSupported && (
+                  <span className="field-label mt-1">This browser cannot encode AVIF.</span>
+                )}
               </label>
               {format !== 'png' && (
                 <label className="space-y-1">

--- a/src/operations/convert-image/meta.js
+++ b/src/operations/convert-image/meta.js
@@ -1,7 +1,7 @@
 export default {
   id: 'convert-image',
   name: 'Convert Image Format',
-  description: 'Convert between PNG, JPEG, and WebP.',
+  description: 'Convert between PNG, JPEG, WebP, and AVIF.',
   category: 'image',
   icon: 'convert',
   order: 22,


### PR DESCRIPTION
Closes #116.

Adds AVIF as an input and output format for Convert Image, fully client-side.

- Decodes AVIF through the browser's native image decoding (same path as other formats).
- Encodes to `image/avif` via canvas when supported.
- Detects AVIF encoding support up front and shows a clear inline note instead of producing a broken file on browsers that cannot encode it.
- Updates the supported-format hints and output extensions.
- Ran `npm run build` and the Static Network Scan locally: no external URL references introduced.