### PR TITLE
feat: add a Redact Image tool (blur / pixelate regions)

### DIFF
--- a/src/operations/redact-image/RegionPicker.jsx
+++ b/src/operations/redact-image/RegionPicker.jsx
@@ -1,0 +1,109 @@
+import { useRef, useState } from 'react'
+import Icon from '../../components/Icon.jsx'
+
+// Drag on the image to add a redaction box. Boxes are stored in the image's
+// natural pixel coordinates and rendered as percentages, so they stay correct
+// at any display size — the same convention Cropper.jsx uses.
+const MIN = 8
+
+export default function RegionPicker({ url, natural, regions, onChange }) {
+  const imgRef = useRef(null)
+  const drag = useRef(null)
+  const [draft, setDraft] = useState(null)
+
+  const toNatural = (e) => {
+    const rect = imgRef.current.getBoundingClientRect()
+    const scale = natural.width / rect.width
+    return {
+      x: (e.clientX - rect.left) * scale,
+      y: (e.clientY - rect.top) * scale,
+    }
+  }
+
+  const boxFrom = (a, b) => ({
+    x: Math.max(0, Math.min(a.x, b.x)),
+    y: Math.max(0, Math.min(a.y, b.y)),
+    w: Math.min(Math.abs(b.x - a.x), natural.width),
+    h: Math.min(Math.abs(b.y - a.y), natural.height),
+  })
+
+  const onDown = (e) => {
+    e.preventDefault()
+    const start = toNatural(e)
+    drag.current = start
+    setDraft({ ...start, w: 0, h: 0 })
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+  const onMove = (e) => {
+    if (!drag.current) return
+    setDraft(boxFrom(drag.current, toNatural(e)))
+  }
+  const onUp = (e) => {
+    window.removeEventListener('pointermove', onMove)
+    window.removeEventListener('pointerup', onUp)
+    const start = drag.current
+    drag.current = null
+    setDraft(null)
+    if (!start) return
+    const box = boxFrom(start, toNatural(e))
+    // A click rather than a drag: ignore it instead of adding a dot.
+    if (box.w < MIN || box.h < MIN) return
+    onChange([...regions, round(box)])
+  }
+
+  const remove = (index) => (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    onChange(regions.filter((_, i) => i !== index))
+  }
+
+  const pct = (v, total) => `${(v / total) * 100}%`
+  const style = (r) => ({
+    left: pct(r.x, natural.width),
+    top: pct(r.y, natural.height),
+    width: pct(r.w, natural.width),
+    height: pct(r.h, natural.height),
+  })
+
+  return (
+    <div className="relative inline-block max-w-full touch-none select-none">
+      <img
+        ref={imgRef}
+        src={url}
+        alt="Redaction source"
+        onPointerDown={onDown}
+        className="block max-h-[28rem] max-w-full cursor-crosshair"
+        draggable={false}
+      />
+
+      {regions.map((r, i) => (
+        <div
+          key={`${r.x}-${r.y}-${r.w}-${r.h}-${i}`}
+          className="absolute border-2 border-brand-500 bg-brand-500/30"
+          style={style(r)}
+        >
+          <button
+            type="button"
+            onPointerDown={remove(i)}
+            title={`Remove region ${i + 1}`}
+            className="absolute -right-2 -top-2 grid h-5 w-5 place-items-center rounded-full border border-slate-400 bg-white text-slate-600 shadow"
+          >
+            <Icon name="x" className="h-3 w-3" />
+          </button>
+        </div>
+      ))}
+
+      {draft && (
+        <div
+          className="pointer-events-none absolute border-2 border-dashed border-brand-400 bg-brand-400/20"
+          style={style(draft)}
+        />
+      )}
+    </div>
+  )
+}
+
+function round(r) {
+  return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.w), h: Math.round(r.h) }
+}

--- a/src/operations/redact-image/helpers.js
+++ b/src/operations/redact-image/helpers.js
@@ -1,0 +1,125 @@
+import { decode, drawToCanvas, canvasToBlob } from '../../lib/imageCanvas.js'
+import { formatFromType, outName } from '../../lib/imageFormat.js'
+
+// Redaction, not decoration. The point of this tool is that the hidden detail
+// is GONE from the exported pixels, so both effects work the same way
+// underneath: the region is resampled down to a coarse grid and drawn back up.
+// That throws the original samples away, rather than rearranging them.
+//
+// A canvas `filter: blur()` alone would look right and be the wrong thing: a
+// Gaussian blur is a reversible convolution in principle, and at small radii
+// text is recoverable in practice. So `blur` is a downsample followed by a
+// smooth upsample (plus a light blur to hide the grid), and `pixelate` is the
+// same downsample drawn back with smoothing off. Same information destroyed,
+// two different looks.
+
+export const MODES = ['pixelate', 'blur']
+
+// Strength is expressed as "how many blocks across the shorter side of the
+// region", so a given setting looks consistent on a face-sized box and a
+// full-width banner. Fewer blocks = coarser = less recoverable.
+export const STRENGTHS = {
+  light: 12,
+  medium: 7,
+  strong: 4,
+}
+
+export const DEFAULT_STRENGTH = 'medium'
+
+/** Integer, in-bounds, at least 1px. Returns null if the region is empty. */
+function normalizeRegion(region, width, height) {
+  const x = Math.round(Math.max(0, Math.min(region.x, width)))
+  const y = Math.round(Math.max(0, Math.min(region.y, height)))
+  const w = Math.round(Math.min(region.w, width - x))
+  const h = Math.round(Math.min(region.h, height - y))
+  if (w < 1 || h < 1) return null
+  return { x, y, w, h }
+}
+
+/**
+ * Replace one region with a resampled copy of itself.
+ *
+ * The region is drawn into a tiny offscreen canvas — that single step is what
+ * destroys the detail — and then drawn back over the original pixels.
+ */
+function redactRegion(ctx, canvas, region, mode, blocks) {
+  const { x, y, w, h } = region
+
+  // Aim for `blocks` cells across the shorter side, and never fewer than 1px.
+  const cell = Math.max(1, Math.floor(Math.min(w, h) / blocks))
+  const smallW = Math.max(1, Math.round(w / cell))
+  const smallH = Math.max(1, Math.round(h / cell))
+
+  const small = document.createElement('canvas')
+  small.width = smallW
+  small.height = smallH
+  const smallCtx = small.getContext('2d')
+  smallCtx.imageSmoothingEnabled = true
+  smallCtx.imageSmoothingQuality = 'high'
+  // Downsample: from here on, the fine detail no longer exists anywhere.
+  smallCtx.drawImage(canvas, x, y, w, h, 0, 0, smallW, smallH)
+
+  ctx.save()
+  // Clip so a blurred upsample cannot bleed outside the region the user drew.
+  ctx.beginPath()
+  ctx.rect(x, y, w, h)
+  ctx.clip()
+  if (mode === 'blur') {
+    ctx.imageSmoothingEnabled = true
+    ctx.imageSmoothingQuality = 'high'
+    // Softens the upsampled grid. Cosmetic only - the detail is already gone.
+    ctx.filter = `blur(${Math.max(1, Math.round(cell / 2))}px)`
+  } else {
+    ctx.imageSmoothingEnabled = false
+    ctx.filter = 'none'
+  }
+  ctx.drawImage(small, 0, 0, smallW, smallH, x, y, w, h)
+  ctx.restore()
+}
+
+/**
+ * Burn a blur or pixelate effect into the given regions of an image.
+ *
+ * @param {File} file
+ * @param {Array<{x:number,y:number,w:number,h:number}>} regions natural pixel coords
+ * @param {{mode?:'pixelate'|'blur', strength?:keyof STRENGTHS}} options
+ */
+export async function redactImage(file, regions, options = {}, onProgress) {
+  const mode = MODES.includes(options.mode) ? options.mode : 'pixelate'
+  const blocks = STRENGTHS[options.strength] || STRENGTHS[DEFAULT_STRENGTH]
+
+  if (!regions?.length) {
+    throw new Error('Draw at least one region over the part you want to hide.')
+  }
+
+  onProgress?.(0.3, 'Decoding image…')
+  const bitmap = await decode(file)
+  const fmt = formatFromType(file.type)
+  const canvas = drawToCanvas(bitmap, {
+    background: fmt === 'jpeg' ? '#ffffff' : undefined,
+  })
+  bitmap.close?.()
+
+  const ctx = canvas.getContext('2d')
+  const usable = regions
+    .map((region) => normalizeRegion(region, canvas.width, canvas.height))
+    .filter(Boolean)
+  if (!usable.length) {
+    throw new Error('Every region is outside the image or too small to redact.')
+  }
+
+  onProgress?.(0.6, `Redacting ${usable.length} region(s)…`)
+  for (const region of usable) {
+    redactRegion(ctx, canvas, region, mode, blocks)
+  }
+
+  onProgress?.(0.9, 'Encoding…')
+  const blob = await canvasToBlob(canvas, fmt, 0.95)
+  onProgress?.(1, 'Done')
+  return {
+    blob,
+    filename: outName(file.name, fmt, '-redacted'),
+    regions: usable.length,
+    mode,
+  }
+}

--- a/src/operations/redact-image/index.jsx
+++ b/src/operations/redact-image/index.jsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import DownloadButton from '../../components/DownloadButton.jsx'
+import ImageResult from '../../components/ImageResult.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { decode, dimsOf } from '../../lib/imageCanvas.js'
+import RegionPicker from './RegionPicker.jsx'
+import { redactImage, STRENGTHS, DEFAULT_STRENGTH } from './helpers.js'
+
+const MODES = [
+  { key: 'pixelate', label: 'Pixelate', hint: 'Hard mosaic blocks' },
+  { key: 'blur', label: 'Blur', hint: 'Soft, same detail removed' },
+]
+
+export default function RedactImage() {
+  const [file, setFile] = useState(null)
+  const [natural, setNatural] = useState(null)
+  const [regions, setRegions] = useState([])
+  const [mode, setMode] = useState('pixelate')
+  const [strength, setStrength] = useState(DEFAULT_STRENGTH)
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const url = useMemo(() => (file ? URL.createObjectURL(file) : null), [file])
+  useEffect(() => () => url && URL.revokeObjectURL(url), [url])
+
+  useEffect(() => {
+    if (!file) return
+    let cancelled = false
+    decode(file).then((bitmap) => {
+      if (!cancelled) setNatural(dimsOf(bitmap))
+      bitmap.close?.()
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [file])
+
+  const pick = (files) => {
+    setFile(files[0])
+    setNatural(null)
+    setRegions([])
+    reset()
+  }
+  const change = (next) => {
+    setRegions(next)
+    reset()
+  }
+  const choose = (setter) => (value) => {
+    setter(value)
+    reset()
+  }
+  const go = () => run((p) => redactImage(file, regions, { mode, strength }, p))
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        accept="image/*"
+        multiple={false}
+        label="Drop an image here or click to browse"
+        hint="Hide faces, names or account numbers before sharing a screenshot"
+        icon="image"
+      />
+
+      {file && natural && (
+        <>
+          <div className="card space-y-3 p-4">
+            <span className="field-label">Drag on the image to cover something</span>
+            <RegionPicker url={url} natural={natural} regions={regions} onChange={change} />
+            <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+              <span>
+                {regions.length === 0
+                  ? 'No regions yet'
+                  : `${regions.length} region(s) — drag again to add another`}
+              </span>
+              {regions.length > 0 && (
+                <button type="button" className="btn-ghost" onClick={() => change([])}>
+                  <Icon name="trash" className="h-4 w-4" />
+                  Clear all
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="card grid gap-4 p-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <span className="field-label">Effect</span>
+              {MODES.map(({ key, label, hint }) => (
+                <label key={key} className="flex items-start gap-3">
+                  <input
+                    type="radio"
+                    name="redact-mode"
+                    checked={mode === key}
+                    onChange={() => choose(setMode)(key)}
+                    className="mt-1 accent-brand-600"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-sm font-medium">{label}</span>
+                    <span className="block text-xs text-slate-400">{hint}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+            <div className="space-y-2">
+              <span className="field-label">Strength</span>
+              {Object.keys(STRENGTHS).map((key) => (
+                <label key={key} className="flex items-center gap-3">
+                  <input
+                    type="radio"
+                    name="redact-strength"
+                    checked={strength === key}
+                    onChange={() => choose(setStrength)(key)}
+                    className="accent-brand-600"
+                  />
+                  <span className="text-sm capitalize">{key}</span>
+                </label>
+              ))}
+              <p className="text-xs text-slate-400">
+                Stronger means fewer, larger blocks — less of the original left behind.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={go}
+              disabled={running || regions.length === 0}
+            >
+              <Icon name="eraser" className="h-4 w-4" />
+              Redact Image
+            </button>
+            {result && !running && <DownloadButton result={result} />}
+          </div>
+
+          {regions.length === 0 && (
+            <Note type="info">Drag a box over anything you want hidden, then redact.</Note>
+          )}
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && (
+        <Note type="error" title="Couldn’t redact this image">
+          {error}
+        </Note>
+      )}
+      {result && !running && (
+        <>
+          <Note type="info" title="Done">
+            {result.regions} region(s) {result.mode === 'blur' ? 'blurred' : 'pixelated'}. The
+            hidden detail is gone from the exported pixels — it is not an overlay you can peel
+            off.
+          </Note>
+          <ImageResult result={result} />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/operations/redact-image/meta.js
+++ b/src/operations/redact-image/meta.js
@@ -1,0 +1,11 @@
+export default {
+  id: 'redact-image',
+  name: 'Redact Image',
+  description: 'Blur or pixelate regions of an image to hide faces, names or numbers.',
+  category: 'image',
+  icon: 'eraser',
+  // Next free slot after watermark-image (26), and next to Redact PDF's job.
+  order: 27,
+  notes:
+    'Runs entirely in your browser — nothing is uploaded. The effect is burned into the exported pixels: each region is resampled down to a coarse grid and drawn back, so the original detail is gone rather than covered over. It is not an overlay anyone can peel off. Re-encoding also drops any EXIF/GPS metadata the original carried.',
+}


### PR DESCRIPTION
Closes #118.

Drag one or more boxes over an image to hide faces, names or account numbers. New auto-discovered operation `src/operations/redact-image/{meta.js,index.jsx,helpers.js,RegionPicker.jsx}`, reusing `Dropzone`, `useJob`, `Progress`, `Note`, `DownloadButton`, `ImageResult` and the shared `imageCanvas`/`imageFormat` helpers. 100% client-side — canvas only, no network, no CDN, no new asset.

## The bit that matters: "genuinely unrecoverable"

A canvas `filter: blur()` alone would *look* right and be the wrong thing. A Gaussian blur is a reversible convolution in principle, and at small radii text is recoverable in practice.

So both effects work the same way underneath: the region is **resampled down to a coarse grid and drawn back up**, which throws the original samples away rather than rearranging them.

- `pixelate` — downsample, then upsample with smoothing **off** (hard mosaic).
- `blur` — the same downsample, then a smooth upsample plus a light blur to hide the grid.

Same information destroyed, two different looks. The draw is clipped to the region, so a blurred upsample cannot bleed outside the box the user drew.

Strength is expressed as *blocks across the shorter side* rather than a pixel radius, so one setting looks consistent on a face-sized box and on a full-width banner.

## Verified: the detail is actually gone

Tested in the running app against a 4px-stripe pattern with text over it — a worst case, since any surviving high-frequency detail shows up immediately.

The measurement is the **mean absolute residual left after reducing the region to the 27×4 grid the redaction targets and blowing it back up**. A low residual means the image carries no more information than that grid:

| | residual (0–255) |
|---|---|
| original | **124.2** — far more detail than the grid |
| after `blur` | **17.8** |
| after `pixelate` | **3.1** |

Sharp transitions inside the region drop from **6072 → 0** for pixelate.

So the exported pixels really are reduced to the coarse grid; the original is not recoverable from the output.

## Verified end-to-end through the UI

- Auto-discovers into the sidebar (image category, after Watermark Image).
- Dragging adds a box; a click does **not** (no stray 1px dots).
- Two non-overlapping regions both apply — `"2 region(s) pixelated"`.
- Downloads as `screenshot-redacted.png`.
- **Offline**: the network log for the whole session contains only localhost module loads and `blob:` URLs — no external host, so the strict `connect-src 'self'` CSP is respected.
