### PR TITLE
feat: add image brightness contrast saturation tool

### DIFF
--- a/src/operations/adjust-image/helpers.js
+++ b/src/operations/adjust-image/helpers.js
@@ -1,0 +1,52 @@
+import { decode, dimsOf, canvasToBlob } from '../../lib/imageCanvas.js'
+import { formatFromType, outName } from '../../lib/imageFormat.js'
+
+/**
+ * @param {File} file
+ * @param {{brightness:number, contrast:number, saturation:number, quality:number}} opts
+ */
+export async function adjustImage(file, opts, onProgress) {
+  const { brightness = 0, contrast = 0, saturation = 100, quality = 0.95 } = opts || {}
+  onProgress?.(0.2, `Adjusting ${file.name}…`)
+
+  const bitmap = await decode(file)
+  const src = dimsOf(bitmap)
+  const canvas = document.createElement('canvas')
+  canvas.width = src.width
+  canvas.height = src.height
+  const ctx = canvas.getContext('2d')
+  ctx.filter = [
+    `brightness(${1 + Number(brightness) / 100})`,
+    `contrast(${1 + Number(contrast) / 100})`,
+    `saturate(${Number(saturation) / 100})`,
+  ].join(' ')
+  ctx.drawImage(bitmap, 0, 0)
+
+  const fmt = formatFromType(file.type)
+  const blob = await canvasToBlob(canvas, fmt, quality)
+  bitmap.close?.()
+
+  return {
+    blob,
+    filename: outName(file.name, fmt, '-adjusted'),
+    before: file.size,
+    after: blob.size,
+    width: src.width,
+    height: src.height,
+  }
+}
+
+/**
+ * Apply the same settings to every selected image.
+ * @param {File[]} files
+ * @param {{brightness:number, contrast:number, saturation:number, quality:number}} opts
+ */
+export async function adjustImages(files, opts, onProgress) {
+  const results = []
+  for (let i = 0; i < files.length; i += 1) {
+    onProgress?.(i / files.length, `Adjusting ${i + 1} of ${files.length}…`)
+    results.push(await adjustImage(files[i], opts, onProgress))
+  }
+  onProgress?.(1, 'Done')
+  return results
+}

--- a/src/operations/adjust-image/index.jsx
+++ b/src/operations/adjust-image/index.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import ResultGallery from '../../components/ResultGallery.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes } from '../../lib/format.js'
+import { adjustImages } from './helpers.js'
+
+export default function AdjustImage() {
+  const [files, setFiles] = useState([])
+  const [brightness, setBrightness] = useState(0)
+  const [contrast, setContrast] = useState(0)
+  const [saturation, setSaturation] = useState(100)
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const previewUrl = useMemo(() => (files[0] ? URL.createObjectURL(files[0]) : null), [files])
+  useEffect(() => () => {
+    if (previewUrl) URL.revokeObjectURL(previewUrl)
+  }, [previewUrl])
+
+  const pick = (chosen) => {
+    setFiles(chosen)
+    reset()
+  }
+  const resetSettings = () => {
+    setBrightness(0)
+    setContrast(0)
+    setSaturation(100)
+  }
+  const go = () =>
+    run((p) =>
+      adjustImages(files, {
+        brightness: Number(brightness),
+        contrast: Number(contrast),
+        saturation: Number(saturation),
+      }, p),
+    )
+
+  const filterStyle = {
+    filter: [
+      `brightness(${1 + Number(brightness) / 100})`,
+      `contrast(${1 + Number(contrast) / 100})`,
+      `saturate(${Number(saturation) / 100})`,
+    ].join(' '),
+  }
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        files={files}
+        accept="image/*"
+        multiple
+        label="Drop one or more images here or click to browse"
+        hint="JPEG, PNG, WebP, or AVIF"
+        icon="image"
+      />
+
+      {files.length > 0 && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="image" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+              {files.length} image{files.length === 1 ? '' : 's'} selected
+            </span>
+            <span className="text-xs text-slate-400">{formatBytes(files.reduce((n, f) => n + f.size, 0))}</span>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+            <div className="card flex items-center justify-center overflow-hidden p-4">
+              {previewUrl ? (
+                <img src={previewUrl} alt="Live preview" style={filterStyle} className="max-h-96 max-w-full object-contain" />
+              ) : (
+                <Note type="info">Select an image to see a live preview.</Note>
+              )}
+            </div>
+
+            <div className="card space-y-5 p-4">
+              <label className="block space-y-1">
+                <span className="field-label">Brightness: {brightness > 0 ? `+${brightness}` : brightness}</span>
+                <input type="range" min="-100" max="100" value={brightness} onChange={(e) => setBrightness(e.target.value)} className="w-full accent-brand-600" />
+              </label>
+              <label className="block space-y-1">
+                <span className="field-label">Contrast: {contrast > 0 ? `+${contrast}` : contrast}</span>
+                <input type="range" min="-100" max="100" value={contrast} onChange={(e) => setContrast(e.target.value)} className="w-full accent-brand-600" />
+              </label>
+              <label className="block space-y-1">
+                <span className="field-label">Saturation: {saturation}%</span>
+                <input type="range" min="0" max="200" value={saturation} onChange={(e) => setSaturation(e.target.value)} className="w-full accent-brand-600" />
+              </label>
+
+              <button type="button" className="btn-secondary w-full" onClick={resetSettings}>
+                Reset adjustments
+              </button>
+            </div>
+          </div>
+
+          <button type="button" className="btn-primary" onClick={go} disabled={running}>
+            <Icon name="contrast" className="h-4 w-4" />
+            Adjust {files.length > 1 ? `${files.length} images` : 'image'}
+          </button>
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && <Note type="error" title="Adjustment failed">{error}</Note>}
+      {result && !running && <ResultGallery results={result} zipName="adjusted-images.zip" />}
+    </div>
+  )
+}

--- a/src/operations/adjust-image/meta.js
+++ b/src/operations/adjust-image/meta.js
@@ -1,0 +1,8 @@
+export default {
+  id: 'adjust-image',
+  name: 'Adjust Image',
+  description: 'Brightness, contrast, and saturation with a live preview.',
+  category: 'image',
+  icon: 'contrast',
+  order: 22,
+}


### PR DESCRIPTION
Closes #95.

Adds a self-contained `src/operations/adjust-image/` operation with:
- Live brightness, contrast, and saturation preview.
- Reset button.
- Batch processing for multiple selected images.
- 100% client-side canvas filtering and export; no network calls or external assets.

Verified with `npm run build`; the new tool page prerenders with the other operations.