### PR TITLE
feat: give every image dropzone a supported-formats hint

### DIFF
--- a/src/lib/imageCanvas.js
+++ b/src/lib/imageCanvas.js
@@ -12,6 +12,11 @@ const MIME = {
 
 export const FORMAT_EXT = { avif: 'avif', jpeg: 'jpg', png: 'png', webp: 'webp' }
 
+// One wording for every dropzone whose tool decodes and re-encodes through this module, so the
+// hint cannot drift from FORMAT_EXT above. Tools with their own encoder (compress-image runs
+// browser-image-compression, which has no AVIF) keep their own hint.
+export const IMAGE_FORMATS_HINT = 'JPEG, PNG, WebP, or AVIF'
+
 /** Detect whether the browser can encode the given MIME type. */
 export function canEncode(mime) {
   const canvas = document.createElement('canvas')

--- a/src/operations/adjust-image/index.jsx
+++ b/src/operations/adjust-image/index.jsx
@@ -7,6 +7,7 @@ import ResultGallery from '../../components/ResultGallery.jsx'
 import { useJob } from '../../hooks/useJob.js'
 import { formatBytes } from '../../lib/format.js'
 import { adjustImages } from './helpers.js'
+import { IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
 
 export default function AdjustImage() {
   const [files, setFiles] = useState([])
@@ -54,7 +55,7 @@ export default function AdjustImage() {
         accept="image/*"
         multiple
         label="Drop one or more images here or click to browse"
-        hint="JPEG, PNG, WebP, or AVIF"
+        hint={IMAGE_FORMATS_HINT}
         icon="image"
       />
 

--- a/src/operations/convert-image/index.jsx
+++ b/src/operations/convert-image/index.jsx
@@ -6,7 +6,7 @@ import Icon from '../../components/Icon.jsx'
 import ImageResult from '../../components/ImageResult.jsx'
 import { useJob } from '../../hooks/useJob.js'
 import { formatBytes } from '../../lib/format.js'
-import { canEncode } from '../../lib/imageCanvas.js'
+import { canEncode, IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
 import { convertImage } from './helpers.js'
 
 export default function ConvertImage() {
@@ -24,7 +24,7 @@ export default function ConvertImage() {
 
   return (
     <div className="space-y-6">
-      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" icon="image" />
+      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" hint={IMAGE_FORMATS_HINT} icon="image" />
 
       {file && (
         <>

--- a/src/operations/crop-image/index.jsx
+++ b/src/operations/crop-image/index.jsx
@@ -6,7 +6,7 @@ import Icon from '../../components/Icon.jsx'
 import ImageResult from '../../components/ImageResult.jsx'
 import Cropper from './Cropper.jsx'
 import { useJob } from '../../hooks/useJob.js'
-import { decode, dimsOf } from '../../lib/imageCanvas.js'
+import { decode, dimsOf, IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
 import { cropImage } from './helpers.js'
 
 export default function CropImage() {
@@ -42,7 +42,7 @@ export default function CropImage() {
 
   return (
     <div className="space-y-6">
-      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" icon="image" />
+      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" hint={IMAGE_FORMATS_HINT} icon="image" />
 
       {file && natural && sel && (
         <>

--- a/src/operations/greyscale-image/index.jsx
+++ b/src/operations/greyscale-image/index.jsx
@@ -7,6 +7,7 @@ import Icon from "../../components/Icon.jsx"
 import { useJob } from "../../hooks/useJob.js"
 import { formatBytes } from "../../lib/format.js"
 import { convertImagetoGreyscale } from "./helper.js"
+import { IMAGE_FORMATS_HINT } from "../../lib/imageCanvas.js"
 
 
 export default function ConvertImagetoGreyscale() {
@@ -21,7 +22,7 @@ export default function ConvertImagetoGreyscale() {
 
     return (
         <div className="space-y-6">
-            <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" icon="image" />
+            <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" hint={IMAGE_FORMATS_HINT} icon="image" />
 
             {file && (
                 <>

--- a/src/operations/invert-image/index.jsx
+++ b/src/operations/invert-image/index.jsx
@@ -7,6 +7,7 @@ import Icon from "../../components/Icon.jsx"
 import { invertImage } from "./helper"
 import { useJob } from "../../hooks/useJob.js"
 import { formatBytes } from "../../lib/format.js"
+import { IMAGE_FORMATS_HINT } from "../../lib/imageCanvas.js"
 
 
 export default function InvertImage() {
@@ -21,7 +22,7 @@ export default function InvertImage() {
 
     return (
         <div className="space-y-6">
-            <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" icon="image" />
+            <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" hint={IMAGE_FORMATS_HINT} icon="image" />
 
             {file && (
                 <>

--- a/src/operations/redact-image/index.jsx
+++ b/src/operations/redact-image/index.jsx
@@ -6,7 +6,7 @@ import Icon from '../../components/Icon.jsx'
 import DownloadButton from '../../components/DownloadButton.jsx'
 import ImageResult from '../../components/ImageResult.jsx'
 import { useJob } from '../../hooks/useJob.js'
-import { decode, dimsOf } from '../../lib/imageCanvas.js'
+import { decode, dimsOf, IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
 import RegionPicker from './RegionPicker.jsx'
 import { redactImage, STRENGTHS, DEFAULT_STRENGTH } from './helpers.js'
 
@@ -61,7 +61,7 @@ export default function RedactImage() {
         accept="image/*"
         multiple={false}
         label="Drop an image here or click to browse"
-        hint="Hide faces, names or account numbers before sharing a screenshot"
+        hint={`${IMAGE_FORMATS_HINT} — hide faces, names or account numbers before sharing a screenshot`}
         icon="image"
       />
 

--- a/src/operations/resize-image/index.jsx
+++ b/src/operations/resize-image/index.jsx
@@ -6,7 +6,7 @@ import Icon from '../../components/Icon.jsx'
 import ImageResult from '../../components/ImageResult.jsx'
 import { useJob } from '../../hooks/useJob.js'
 import { formatBytes } from '../../lib/format.js'
-import { decode, dimsOf } from '../../lib/imageCanvas.js'
+import { decode, dimsOf, IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
 import { resizeImage } from './helpers.js'
 
 export default function ResizeImage() {
@@ -49,7 +49,7 @@ export default function ResizeImage() {
 
   return (
     <div className="space-y-6">
-      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" icon="image" />
+      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" hint={IMAGE_FORMATS_HINT} icon="image" />
 
       {file && (
         <>

--- a/src/operations/rotate-flip-image/index.jsx
+++ b/src/operations/rotate-flip-image/index.jsx
@@ -7,6 +7,7 @@ import ImageResult from '../../components/ImageResult.jsx'
 import { useJob } from '../../hooks/useJob.js'
 import { formatBytes } from '../../lib/format.js'
 import { rotateFlipImage } from './helpers.js'
+import { IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
 
 export default function RotateFlipImage() {
   const [file, setFile] = useState(null)
@@ -23,7 +24,7 @@ export default function RotateFlipImage() {
 
   return (
     <div className="space-y-6">
-      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" icon="image" />
+      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" hint={IMAGE_FORMATS_HINT} icon="image" />
 
       {file && (
         <>

--- a/src/operations/strip-metadata/index.jsx
+++ b/src/operations/strip-metadata/index.jsx
@@ -7,6 +7,7 @@ import ImageResult from '../../components/ImageResult.jsx'
 import { useJob } from '../../hooks/useJob.js'
 import { formatBytes } from '../../lib/format.js'
 import { stripMetadata } from './helpers.js'
+import { IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
 
 export default function StripMetadata() {
   const [file, setFile] = useState(null)
@@ -20,7 +21,7 @@ export default function StripMetadata() {
 
   return (
     <div className="space-y-6">
-      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" hint="JPEG images often carry GPS location and camera EXIF data" icon="image" />
+      <Dropzone onFiles={pick} accept="image/*" multiple={false} label="Drop an image here or click to browse" hint={`${IMAGE_FORMATS_HINT} — JPEGs often carry GPS location and camera EXIF data`} icon="image" />
 
       {file && (
         <>

--- a/src/operations/watermark-image/index.jsx
+++ b/src/operations/watermark-image/index.jsx
@@ -7,6 +7,7 @@ import ResultGallery from '../../components/ResultGallery.jsx'
 import { useJob } from '../../hooks/useJob.js'
 import { formatBytes } from '../../lib/format.js'
 import { watermarkImages, POSITIONS } from './helpers.js'
+import { IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
 
 export default function WatermarkImage() {
   const [files, setFiles] = useState([])
@@ -51,7 +52,7 @@ export default function WatermarkImage() {
         accept="image/*"
         multiple
         label="Drop images here or click to browse"
-        hint="Watermark one image or a whole batch — all of them get the same mark"
+        hint={`${IMAGE_FORMATS_HINT} — one image or a whole batch, all getting the same mark`}
         icon="image"
       />
 


### PR DESCRIPTION
Closes #10.

## What was missing

Six image tools had no dropzone hint at all:

`convert-image` · `crop-image` · `greyscale-image` · `invert-image` · `resize-image` · `rotate-flip-image`

Three more (`redact-image`, `strip-metadata`, `watermark-image`) had a *context* hint but no formats, so the acceptance criterion — "every image tool shows a short supported-formats hint" — was not met for them either.

## The wording has one home

All nine decode and re-encode through `lib/imageCanvas.js`, whose `MIME` map and `FORMAT_EXT` cover exactly `avif, jpeg, png, webp`. So the string lives next to them:

```js
export const IMAGE_FORMATS_HINT = 'JPEG, PNG, WebP, or AVIF'
```

That way the hint cannot drift from the map it describes. `adjust-image` already carried that exact string as a literal and now reads the constant instead.

For the three with existing copy, the formats are prepended rather than replacing it — which is the pattern `images-to-pdf` already uses (`"JPEG, PNG, WebP, GIF, BMP — reorder them below after adding"`). I lower-cased the clause after the dash to match, and reworded `watermark-image`'s so the line doesn't end up carrying two em-dashes.

## Two tools deliberately left alone

**`compress-image` keeps `"JPEG, PNG, or WebP"`.** It does not use `imageCanvas` — its helper runs `browser-image-compression` against its own `MIME = { jpeg, png, webp }` with no AVIF entry, and its format `<select>` offers only those three. The shared constant would over-claim there.

**`images-to-pdf`** already has a hint and its own decode path, so it's untouched.

That is why this is a shared constant used by the tools that share a decoder, rather than one global string stamped on every dropzone.

## Verified in the dev server

| route | rendered hint |
| --- | --- |
| `/convert-image` | `JPEG, PNG, WebP, or AVIF` |
| `/greyscale-image` | `JPEG, PNG, WebP, or AVIF` |
| `/watermark-image` | `JPEG, PNG, WebP, or AVIF — one image or a whole batch, all getting the same mark` |

Read back from the live `[id$="-hint"]` element the `Dropzone` renders. `/greyscale-image` was checked specifically because it is one of the double-quoted files, so its new import line was the most likely to break.

`vite build` passes. (It failed first on `Rollup failed to resolve import "qrcode"` — unrelated: the new `qr-code` tool landed upstream and my `node_modules` predated its dependency. `npm install` fixed it.)

Console shows pre-existing dev-mode `Invalid hook call` and CSP `frame-ancestors` warnings; I confirmed the identical set appears on a clean tree with these changes stashed.
