### PR TITLE
feat(pdf-to-images): transparent-background PNG option

### DIFF
--- a/src/operations/pdf-to-images/helpers.js
+++ b/src/operations/pdf-to-images/helpers.js
@@ -2,15 +2,23 @@ import { loadPdf } from '../../lib/pdfjs.js'
 import { canvasToBlob } from '../../lib/imageCanvas.js'
 import { baseName, parsePageRanges } from '../../lib/format.js'
 
+// pdf.js always paints the canvas before drawing the page: CanvasGraphics.beginDrawing does
+// `ctx.fillStyle = background || '#ffffff'; ctx.fillRect(...)`. So skipping our own fill is not
+// enough to get transparency — the renderer has to be handed a transparent background instead.
+// A fully transparent fillStyle composites to nothing over a fresh canvas, which is already
+// transparent black. JPEG has no alpha channel, so the option only applies to PNG.
+const TRANSPARENT = 'rgba(0,0,0,0)'
+
 /**
  * Render PDF pages to images.
  * @param {File} file
- * @param {{format:'png'|'jpeg', scale:number, range:string, quality:number}} opts
+ * @param {{format:'png'|'jpeg', scale:number, range:string, quality:number, transparent:boolean}} opts
  * @param {(v:number,m:string)=>void} onProgress
  * @returns {Promise<{filename:string, blob:Blob, width:number, height:number}[]>}
  */
 export async function pdfToImages(file, opts, onProgress) {
-  const { format = 'png', scale = 2, range = '', quality = 0.92 } = opts || {}
+  const { format = 'png', scale = 2, range = '', quality = 0.92, transparent = false } = opts || {}
+  const wantsTransparency = transparent && format === 'png'
   const data = new Uint8Array(await file.arrayBuffer())
   const pdf = await loadPdf(data)
   const total = pdf.numPages
@@ -32,7 +40,7 @@ export async function pdfToImages(file, opts, onProgress) {
       ctx.fillStyle = '#ffffff'
       ctx.fillRect(0, 0, canvas.width, canvas.height)
     }
-    await page.render({ canvasContext: ctx, viewport }).promise
+    await page.render({ canvasContext: ctx, viewport, ...(wantsTransparency && { background: TRANSPARENT }) }).promise
     const ext = format === 'jpeg' ? 'jpg' : 'png'
     const blob = await canvasToBlob(canvas, format, quality)
     results.push({

--- a/src/operations/pdf-to-images/index.jsx
+++ b/src/operations/pdf-to-images/index.jsx
@@ -14,6 +14,7 @@ export default function PdfToImages() {
   const [format, setFormat] = useState('png')
   const [scale, setScale] = useState(2)
   const [range, setRange] = useState('')
+  const [transparent, setTransparent] = useState(false)
   const { running, progress, error, result, run, reset, slow, cancel } = useJob()
   const { pageCount } = usePdfPageCount(file)
 
@@ -39,7 +40,7 @@ export default function PdfToImages() {
   }
 
   const convert = () =>
-    run((onProgress) => pdfToImages(file, { format, scale: Number(scale), range }, onProgress))
+    run((onProgress) => pdfToImages(file, { format, scale: Number(scale), range, transparent }, onProgress))
 
   return (
     <div className="space-y-6">
@@ -83,6 +84,14 @@ export default function PdfToImages() {
                 {rangeError && <span className="block text-xs text-red-600 dark:text-red-400">{rangeError}</span>}
               </label>
             </div>
+
+            {/* JPEG has no alpha channel, so the option is only meaningful for PNG. */}
+            {format === 'png' && (
+              <label className="mt-4 flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={transparent} onChange={(e) => setTransparent(e.target.checked)} />
+                Transparent background (keep unpainted areas see-through)
+              </label>
+            )}
           </div>
 
           <div className="flex items-center gap-3">


### PR DESCRIPTION
Closes #25.

Adds a **Transparent background** checkbox to PDF → Images, shown only for PNG (JPEG has no alpha channel), threaded into `pdfToImages` as `opts.transparent`.

## The suggested fix was already in place — and isn't the cause

The issue says to skip the white fill for PNG output. That is already what `helpers.js` does: the explicit `ctx.fillRect` is guarded by `format === 'jpeg'`.

PNG output was still opaque because **pdf.js fills the canvas itself**. In the pinned `pdfjs-dist` 4.x, `CanvasGraphics.beginDrawing`:

```js
beginDrawing({ transform, viewport, transparency = false, background = null }) {
  const width = this.ctx.canvas.width;
  const height = this.ctx.canvas.height;
  const savedFillStyle = this.ctx.fillStyle;
  this.ctx.fillStyle = background || "#ffffff";
  this.ctx.fillRect(0, 0, width, height);
  ...
```

So removing our own fill can never be enough — the renderer has to be *handed* a transparent background. `page.render` now receives `background: 'rgba(0,0,0,0)'` when transparency is requested. A fully transparent `fillStyle` composites to nothing over a fresh canvas (already transparent black), so unpainted areas keep alpha 0 while page content draws normally.

## Verification

Reproduced `beginDrawing`'s two lines exactly, painted a red square the way page content would, encoded to PNG and read the pixels back:

| `background` | unpainted pixel | painted pixel |
| --- | --- | --- |
| `null` (pdf.js default) | `rgba(255,255,255,255)` | `rgba(255,0,0,255)` |
| `'rgba(0,0,0,0)'` (this PR) | **`rgba(0,0,0,0)`** | `rgba(255,0,0,255)` |

Painted content survives either way; only the background changes.

UI checked in the dev server with a real PDF dropped into the dropzone:

| format | checkbox present |
| --- | --- |
| PNG | yes |
| JPEG | no |
| back to PNG | yes |

`vite build` passes.

## One limitation, stated plainly

I could **not** verify this end to end on real exported pixels: `page.render()` never resolves in this preview browser — the job sticks at `Rendering page 1 (1/1)… 0%`. That reproduces on clean `main` with these changes stashed, and pdf.js itself is working there (`usePdfPageCount` reads `1 page` off the same document), so it is the preview pane rather than this change. Worth a quick sanity check on your side against a PDF that actually has transparent regions.

With the option off, the render call is byte-identical to `main` — the conditional spread contributes no properties — so the default path carries no risk.
