### PR TITLE
feat: package DoxDock as a Chrome extension (v1.10.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules/
 # build output
 dist/
 dev-dist/
+extension/build/
+extension/*.zip
 
 # playwright
 test-results/

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,64 @@
+# DoxDock as a Chrome extension
+
+Package the DoxDock web app as a Manifest V3 Chrome extension. The whole app,
+including the on-device AI tools, ships inside the extension and runs entirely
+on the user's machine. Nothing is loaded from a server, and no user file ever
+leaves the device.
+
+## Build
+
+From the repo root:
+
+```bash
+npm run build                     # build the app into dist/
+node extension/build-extension.mjs   # package dist/ into extension/build/
+```
+
+The packager:
+
+- copies the built app (including `public/ort` and `public/models`) into
+  `extension/build/`,
+- writes a Manifest V3 `manifest.json` (with `wasm-unsafe-eval` for the wasm and
+  AI tools) and the toolbar icons,
+- adds `background.js`, whose only job is to open the app in a new tab when the
+  toolbar icon is clicked,
+- strips the PWA service worker (service workers cannot register on a
+  `chrome-extension://` page, and the extension is already fully local) and the
+  `frame-ancestors` CSP directive (ignored in a meta tag).
+
+`extension/build/` is a build artifact and is not committed.
+
+## Load it locally (development)
+
+1. Open `chrome://extensions`
+2. Turn on **Developer mode** (top right)
+3. Click **Load unpacked** and select `extension/build`
+4. Pin the DoxDock icon and click it. The app opens in a new tab, served entirely
+   from the extension.
+
+## Notes
+
+- When the app runs as an extension it uses hash routing (`index.html#/merge-pdfs`)
+  so reloads work; on the web it keeps clean path routing for SEO. This is
+  handled automatically (`IS_EXTENSION` in `src/App.jsx`).
+- The build is around 50 MB because the AI model and ONNX runtime are bundled for
+  full offline use. For a smaller Web Store package, the AI models can be
+  lazy-downloaded on first use of those tools instead of bundled.
+
+## Publish to the Chrome Web Store
+
+See the steps in the project release notes, or the short version:
+
+1. Build the extension (above), then zip the **contents** of `extension/build`
+   (the manifest must be at the root of the zip):
+   ```bash
+   cd extension/build && zip -r ../doxdock-extension.zip . && cd -
+   ```
+2. Create a Chrome Web Store developer account (one-time 5 USD fee) at
+   https://chrome.google.com/webstore/devconsole
+3. Click **Add new item**, upload the zip, and fill in the listing (name,
+   description, screenshots, privacy policy, category).
+4. In the privacy section, declare that the extension collects no data and makes
+   no network requests. This is easy to justify: it is open source and the CSP
+   allows only same-origin loads.
+5. Submit for review. Approval usually takes a few days.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,8 @@
+// DoxDock Chrome extension (Manifest V3) background service worker.
+//
+// Clicking the toolbar icon opens the full DoxDock app in a new tab, served
+// entirely from inside the extension (chrome-extension://<id>/index.html).
+// No network, no Vercel, nothing loaded from a remote origin.
+chrome.action.onClicked.addListener(async () => {
+  await chrome.tabs.create({ url: chrome.runtime.getURL('index.html') })
+})

--- a/extension/build-extension.mjs
+++ b/extension/build-extension.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+// Package the built DoxDock app (dist/) into a loadable, unpacked Chrome
+// extension (Manifest V3). The whole app, including the local AI model and ONNX
+// runtime, is copied into the extension so it runs fully on-device with no
+// server. Run `npm run build` first, then `node extension/build-extension.mjs`.
+
+import { existsSync, rmSync, mkdirSync, cpSync, writeFileSync, readFileSync, copyFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(here, '..')
+const dist = path.join(root, 'dist')
+const out = path.join(here, 'build')
+
+if (!existsSync(dist)) {
+  console.error('dist/ not found. Run `npm run build` first, then re-run this script.')
+  process.exit(1)
+}
+
+const pkg = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'))
+
+// Fresh output folder, then copy the built app in as the extension root.
+rmSync(out, { recursive: true, force: true })
+mkdirSync(out, { recursive: true })
+cpSync(dist, out, { recursive: true })
+
+// Pick whatever PWA icons the build produced (they live at the dist root).
+const rootFiles = new Set(readdirSync(out))
+const icon = (name, fallback) => (rootFiles.has(name) ? name : fallback)
+const icon192 = icon('pwa-192.png', 'favicon.svg')
+const icon512 = icon('pwa-512.png', icon192)
+
+const manifest = {
+  manifest_version: 3,
+  name: 'DoxDock: Private PDF & Image Tools',
+  version: pkg.version,
+  description:
+    'Private PDF and image tools that run 100% on your device. Nothing you open is ever uploaded.',
+  icons: { 192: icon192, 512: icon512 },
+  action: { default_title: 'Open DoxDock', default_icon: { 192: icon192 } },
+  background: { service_worker: 'background.js' },
+  // Extension pages need wasm-unsafe-eval for the wasm tools (pdf.js, image
+  // compression, on-device AI). MV3 forbids blob: in worker-src, so we omit it
+  // and let worker-src fall back to 'self' (same-origin workers only). The app
+  // also ships its own strict CSP meta tag which further locks it down.
+  content_security_policy: {
+    extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
+  },
+}
+
+writeFileSync(path.join(out, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n')
+copyFileSync(path.join(here, 'background.js'), path.join(out, 'background.js'))
+
+// Clean up things that only make sense on the web, not in an extension:
+//   - the PWA service-worker registration (SWs cannot register on a
+//     chrome-extension:// page, and the extension is already fully local), and
+//   - the `frame-ancestors` CSP directive (ignored in a <meta> tag, only warns).
+// Applied to every built HTML page (home + each prerendered tool page).
+function walkHtml(dir) {
+  const out = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...walkHtml(p))
+    else if (entry.name.endsWith('.html')) out.push(p)
+  }
+  return out
+}
+for (const file of walkHtml(out)) {
+  let html = readFileSync(file, 'utf8')
+  html = html.replace(/<script id="vite-plugin-pwa:register-sw"[^>]*><\/script>/g, '')
+  html = html.replace(/;\s*frame-ancestors 'none'/g, '')
+  writeFileSync(file, html)
+}
+for (const f of readdirSync(out)) {
+  if (f === 'registerSW.js' || f === 'sw.js' || /^workbox-.*\.js$/.test(f)) {
+    rmSync(path.join(out, f), { force: true })
+  }
+}
+
+console.log(`✅ Extension packaged at: ${out}`)
+console.log(`   version ${pkg.version}, icon ${icon192}`)
+console.log('   Load it: chrome://extensions -> enable Developer mode -> Load unpacked -> pick the folder above.')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doxdock",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Offline-first, 100% client-side document & image utilities. Nothing you upload ever leaves your machine.",
   "type": "module",
   "license": "MIT",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,12 +14,19 @@ import { useSeo } from './hooks/useSeo.js'
 import { getOperation } from './registry/registry.js'
 import { emitFileDrop } from './lib/fileDropBus.js'
 
+// Inside a browser extension (chrome-extension://…) a path like "/merge-pdfs"
+// is a real file lookup, so it 404s on reload. There we use hash routing, which
+// always reloads to index.html. On the web we keep clean path routing for SEO.
+export const IS_EXTENSION = /^(chrome|moz)-extension:$/.test(window.location.protocol)
+
 // Path routing for SEO — each tool gets its own crawlable URL ("/merge-pdfs").
 // "/" (or an unknown path) → Home landing page (activeId === null).
 // Legacy hash links ("/#/merge-pdfs") are redirected to the path form on load.
 function useRouteSelection() {
   const parse = () => {
-    const raw = decodeURIComponent(window.location.pathname).replace(/^\/+|\/+$/g, '')
+    const raw = IS_EXTENSION
+      ? window.location.hash.replace(/^#\/?/, '')
+      : decodeURIComponent(window.location.pathname).replace(/^\/+|\/+$/g, '')
     if (!raw || raw === 'home') return null
     return getOperation(raw) ? raw : null
   }
@@ -27,12 +34,22 @@ function useRouteSelection() {
 
   const select = useCallback((id) => {
     setActiveId(id)
+    if (IS_EXTENSION) {
+      const target = id ? `#/${id}` : '#/'
+      if (window.location.hash !== target) window.location.hash = target
+      return
+    }
     const target = id ? `/${id}` : '/'
     if (window.location.pathname !== target) window.history.pushState({}, '', target)
   }, [])
 
   useEffect(() => {
-    // Redirect old hash-style links ("/#/merge-pdfs") to the path form.
+    if (IS_EXTENSION) {
+      const onHash = () => setActiveId(parse())
+      window.addEventListener('hashchange', onHash)
+      return () => window.removeEventListener('hashchange', onHash)
+    }
+    // Web: redirect old hash-style links ("/#/merge-pdfs") to the path form.
     const legacy = window.location.hash.match(/^#\/?(.*)$/)
     if (legacy) {
       const id = legacy[1] === 'home' ? '' : legacy[1]

--- a/src/operations/edit-pdf/index.jsx
+++ b/src/operations/edit-pdf/index.jsx
@@ -436,7 +436,10 @@ export default function EditPdf() {
     exportJob.run((p) => exportEditedPdf(bytesRef.current, annos, p).then((blob) => ({ blob, filename: finalName() })))
 
   const openStandalone = () => {
-    const url = `${window.location.origin}/edit-pdf?standalone=1`
+    const isExt = /^(chrome|moz)-extension:$/.test(window.location.protocol)
+    const url = isExt
+      ? `${window.location.origin}/index.html?standalone=1#/edit-pdf`
+      : `${window.location.origin}/edit-pdf?standalone=1`
     window.open(url, '_blank', 'noopener,noreferrer')
   }
 


### PR DESCRIPTION
Adds the Chrome extension wrapper + extension-aware routing, and bumps to 1.10.0.