### PR TITLE
feat: add local SHA-256 file hash operation

### DIFF
--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -10,6 +10,7 @@ const P = {
     '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M17 8l-5-5-5 5"/><path d="M12 3v12"/>',
   download:
     '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/>',
+  copy: '<rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
   x: '<path d="M18 6 6 18"/><path d="M6 6l12 12"/>',
   search: '<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>',
   command:

--- a/src/operations/file-hash/helpers.js
+++ b/src/operations/file-hash/helpers.js
@@ -1,0 +1,21 @@
+export function normalizeExpectedHash(value) {
+  return String(value || '').replace(/\s+/g, '').toLowerCase()
+}
+
+export function isValidExpectedHash(value) {
+  return /^[a-f0-9]{64}$/.test(normalizeExpectedHash(value))
+}
+
+export async function sha256Hex(data) {
+  const bytes = data instanceof ArrayBuffer ? data : await data.arrayBuffer()
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export async function hashFile(file, onProgress) {
+  if (!file) throw new Error('Choose a file to hash.')
+  onProgress?.(0.2, 'Reading file locally…')
+  const hash = await sha256Hex(file)
+  onProgress?.(1, 'Done')
+  return hash
+}

--- a/src/operations/file-hash/helpers.test.js
+++ b/src/operations/file-hash/helpers.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { isValidExpectedHash, normalizeExpectedHash, sha256Hex } from './helpers.js'
+
+describe('file hash helpers', () => {
+  it('normalizes and validates expected SHA-256 values', () => {
+    const hash = 'A'.repeat(64)
+    expect(normalizeExpectedHash(` ${hash.slice(0, 32)}\n${hash.slice(32)} `)).toBe(hash.toLowerCase())
+    expect(isValidExpectedHash(hash)).toBe(true)
+    expect(isValidExpectedHash(`${hash}0`)).toBe(false)
+    expect(isValidExpectedHash('not-a-hash')).toBe(false)
+  })
+
+  it('hashes an ArrayBuffer with SHA-256', async () => {
+    const bytes = new TextEncoder().encode('hello')
+    await expect(sha256Hex(bytes.buffer)).resolves.toBe(
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    )
+  })
+})

--- a/src/operations/file-hash/index.jsx
+++ b/src/operations/file-hash/index.jsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes } from '../../lib/format.js'
+import { hashFile, isValidExpectedHash, normalizeExpectedHash } from './helpers.js'
+
+export default function FileHash() {
+  const [file, setFile] = useState(null)
+  const [expected, setExpected] = useState('')
+  const [copied, setCopied] = useState(false)
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const pick = (files) => {
+    setFile(files[0])
+    setCopied(false)
+    reset()
+  }
+
+  const go = () => run((p) => hashFile(file, p))
+
+  const copy = async () => {
+    if (!result) return
+    await navigator.clipboard.writeText(result)
+    setCopied(true)
+  }
+
+  const normalizedExpected = normalizeExpectedHash(expected)
+  const expectedInvalid = normalizedExpected.length > 0 && !isValidExpectedHash(expected)
+  const matches = result && isValidExpectedHash(expected) && result === normalizedExpected
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        multiple={false}
+        label="Drop a file here or click to browse"
+        hint="SHA-256 is calculated locally in your browser"
+      />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="fileText" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+            <span className="text-xs text-slate-400">{formatBytes(file.size)}</span>
+          </div>
+          <label className="block space-y-1">
+            <span className="field-label">Expected SHA-256 hash (optional)</span>
+            <input
+              className="field-input font-mono"
+              value={expected}
+              onChange={(event) => setExpected(event.target.value)}
+              placeholder="64 hexadecimal characters"
+              spellCheck="false"
+              aria-invalid={expectedInvalid}
+            />
+            {expectedInvalid && <span className="text-sm text-red-600">Enter exactly 64 hexadecimal characters.</span>}
+          </label>
+          <button type="button" className="btn-primary" onClick={go} disabled={running || expectedInvalid}>
+            <Icon name="hash" className="h-4 w-4" />
+            Calculate SHA-256
+          </button>
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && <Note type="error" title="Hashing failed">{error}</Note>}
+      {result && !running && (
+        <div className="card space-y-3 p-4">
+          <div className="flex items-start gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-slate-600 dark:text-slate-300">SHA-256 checksum</p>
+              <code className="mt-1 block break-all font-mono text-sm text-slate-900 dark:text-slate-100">{result}</code>
+            </div>
+            <button type="button" className="btn-secondary shrink-0" onClick={copy}>
+              <Icon name={copied ? 'check' : 'copy'} className="h-4 w-4" />
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          {isValidExpectedHash(expected) && (
+            <Note type={matches ? 'info' : 'warning'} title={matches ? 'Hash matches' : 'Hash does not match'}>
+              The calculated checksum {matches ? 'matches' : 'does not match'} the expected value.
+            </Note>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/operations/file-hash/meta.js
+++ b/src/operations/file-hash/meta.js
@@ -1,0 +1,9 @@
+export default {
+  id: 'file-hash',
+  name: 'File Hash / Checksum',
+  description: 'Calculate a local SHA-256 checksum and optionally compare it with an expected hash.',
+  category: 'other',
+  icon: 'hash',
+  order: 41,
+  notes: 'Files stay in your browser. Nothing is uploaded or persisted.',
+}


### PR DESCRIPTION
## Summary
- add an auto-discovered file-hash operation using browser Web Crypto SHA-256
- keep file contents local with no dependency or network path
- add optional normalized expected-hash comparison and copyable output
- add focused helper tests

## Verification
- `npm test -- --run src/operations/file-hash/helpers.test.js` (2 passed)
- `npm run build` (passed; 35 prerendered URLs)
- `git diff --check` (passed)

Closes #156