### PR TITLE
feat: add ZIP archive builder

### DIFF
--- a/src/operations/zip-files/helpers.js
+++ b/src/operations/zip-files/helpers.js
@@ -1,0 +1,20 @@
+import { zipFiles as createZip } from '../../lib/zip.js'
+
+export async function zipFiles(files, onProgress) {
+  if (!files || files.length < 2) {
+    throw new Error('Add at least two files to create a ZIP.')
+  }
+
+  const entries = files.map((file) => ({
+    filename: file.name,
+    blob: file,
+  }))
+
+  onProgress?.(0.5, `Preparing ${files.length} files…`)
+
+  const blob = await createZip(entries)
+
+  onProgress?.(1, 'ZIP created successfully.')
+
+  return blob
+}

--- a/src/operations/zip-files/index.jsx
+++ b/src/operations/zip-files/index.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import FileList from '../../components/FileList.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import DownloadButton from '../../components/DownloadButton.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { zipFiles } from './helpers.js'
+
+export default function ZipFiles() {
+  const [files, setFiles] = useState([])
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const add = (incoming) => {
+    setFiles((prev) => [...prev, ...incoming])
+    reset()
+  }
+
+const create = () =>
+  run((onProgress) =>
+    zipFiles(files, onProgress).then((blob) => ({
+      blob,
+      filename: 'archive.zip',
+    })),
+  )
+
+  return (
+  <div className="space-y-6">
+    <Dropzone
+      onFiles={add}
+      files={files}
+      accept="*/*"
+      label="Drop files here or click to browse"
+      hint="Add two or more files to create a ZIP"
+      icon="fileOut"
+    />
+
+    {files.length > 0 && (
+      <FileList
+        files={files}
+        onRemove={(i) =>
+          setFiles((prev) => prev.filter((_, index) => index !== i))
+        }
+        onClear={() => {
+          setFiles([])
+          reset()
+        }}
+      />
+    )}
+
+    {files.length > 0 && (
+  <div className="flex flex-wrap items-center gap-3">
+    <button
+      type="button"
+      className="btn-primary"
+      onClick={create}
+      disabled={running || files.length < 2}
+    >
+      <Icon name="fileOut" className="h-4 w-4" />
+      Create ZIP
+    </button>
+
+    {result && <DownloadButton result={result} />}
+  </div>
+)}
+ {running && progress && (
+      <Progress
+        value={progress.value}
+        message={progress.message}
+      />
+    )}
+
+    {error && (
+      <Note type="error" title="ZIP creation failed">
+        {error}
+      </Note>
+    )}
+  </div>
+)
+}

--- a/src/operations/zip-files/meta.js
+++ b/src/operations/zip-files/meta.js
@@ -1,0 +1,8 @@
+export default {
+  id: 'zip-files',
+  name: 'ZIP Files',
+  description: 'Bundle multiple files into a single ZIP archive.',
+  category: 'other',
+  icon: 'fileOut',
+  order: 40,
+}


### PR DESCRIPTION
Closes #157

## What changed
- Added a new ZIP archive builder operation.
- Allows users to select multiple files and create a downloadable ZIP.
- Uses the existing `fflate` dependency for in-browser ZIP creation.
- Works entirely client-side with no external network requests.

## Acceptance criteria
- [x] Multiple files combine into one downloadable .zip.
- [x] Runs fully offline.

## Proof
- Build completed successfully.
- Tested the ZIP creation feature locally.