### PR TITLE
feat: add image splitter

### DIFF
--- a/src/operations/split-image/helpers.js
+++ b/src/operations/split-image/helpers.js
@@ -1,0 +1,86 @@
+import { decode, dimsOf, canvasToBlob } from '../../lib/imageCanvas.js'
+
+export async function splitImage(file, opts, onProgress) {
+  if (!file) {
+    throw new Error('Please select an image to split.')
+  }
+
+  const rows = Math.floor(Number(opts?.rows))
+  const columns = Math.floor(Number(opts?.columns))
+
+  if (!Number.isInteger(rows) || rows < 1 || rows > 20) {
+    throw new Error('Rows must be a whole number between 1 and 20.')
+  }
+
+  if (!Number.isInteger(columns) || columns < 1 || columns > 20) {
+    throw new Error('Columns must be a whole number between 1 and 20.')
+  }
+
+  onProgress?.(0.1, 'Loading image...')
+
+  const bitmap = await decode(file)
+  const { width, height } = dimsOf(bitmap)
+
+  const total = rows * columns
+  const results = []
+
+  const format = 'png'
+
+  try {
+    for (let row = 0; row < rows; row += 1) {
+      const startY = Math.floor((row * height) / rows)
+      const endY = Math.floor(((row + 1) * height) / rows)
+      const tileHeight = endY - startY
+
+      for (let column = 0; column < columns; column += 1) {
+        const startX = Math.floor((column * width) / columns)
+        const endX = Math.floor(((column + 1) * width) / columns)
+        const tileWidth = endX - startX
+
+        const canvas = document.createElement('canvas')
+        canvas.width = tileWidth
+        canvas.height = tileHeight
+
+        const ctx = canvas.getContext('2d')
+
+        if (!ctx) {
+          throw new Error('Could not prepare an image tile.')
+        }
+
+        ctx.drawImage(
+          bitmap,
+          startX,
+          startY,
+          tileWidth,
+          tileHeight,
+          0,
+          0,
+          tileWidth,
+          tileHeight,
+        )
+
+        const blob = await canvasToBlob(canvas, format)
+
+        const tileNumber = row * columns + column + 1
+
+        results.push({
+          blob,
+          filename: `tile-${tileNumber}.png`,
+          width: tileWidth,
+          height: tileHeight,
+        })
+
+        onProgress?.(
+          tileNumber / total,
+          `Creating tile ${tileNumber} of ${total}...`,
+        )
+      }
+    }
+  } finally {
+    bitmap.close?.()
+  }
+
+  onProgress?.(1, 'Done')
+
+  return results
+}

--- a/src/operations/split-image/index.jsx
+++ b/src/operations/split-image/index.jsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import ResultGallery from '../../components/ResultGallery.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
+import { splitImage } from './helpers.js'
+
+export default function SplitImage() {
+  const [file, setFile] = useState(null)
+  const [rows, setRows] = useState(2)
+  const [columns, setColumns] = useState(2)
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const pick = (files) => {
+    setFile(files[0] || null)
+    reset()
+  }
+
+  const go = () => {
+    if (!file) return
+
+    run((onProgress) =>
+      splitImage(
+        file,
+        {
+          rows: Number(rows),
+          columns: Number(columns),
+        },
+        onProgress,
+      ),
+    )
+  }
+
+  const totalTiles = Number(rows) * Number(columns)
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        files={file ? [file] : []}
+        accept="image/*"
+        multiple={false}
+        label="Drop an image here or click to browse"
+        hint={IMAGE_FORMATS_HINT}
+        icon="image"
+      />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="image" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+              {file.name}
+            </span>
+          </div>
+
+          <div className="card p-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="space-y-1">
+                <span className="field-label">Rows</span>
+                <input
+                  type="number"
+                  min="1"
+                  max="20"
+                  step="1"
+                  className="field-input"
+                  value={rows}
+                  onChange={(e) => setRows(e.target.value)}
+                />
+              </label>
+
+              <label className="space-y-1">
+                <span className="field-label">Columns</span>
+                <input
+                  type="number"
+                  min="1"
+                  max="20"
+                  step="1"
+                  className="field-input"
+                  value={columns}
+                  onChange={(e) => setColumns(e.target.value)}
+                />
+              </label>
+            </div>
+
+            <Note type="info" className="mt-4">
+              This will create {totalTiles} tile{totalTiles === 1 ? '' : 's'} and
+              download them together as a ZIP.
+            </Note>
+          </div>
+
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={go}
+            disabled={running}
+          >
+            <Icon name="grid" className="h-4 w-4" />
+            {running ? 'Splitting image...' : 'Split image'}
+          </button>
+        </>
+      )}
+
+      {running && progress && (
+        <Progress
+          value={progress.value}
+          message={progress.message}
+        />
+      )}
+
+      {error && (
+        <Note type="error" title="Image split failed">
+          {error}
+        </Note>
+      )}
+
+      {result && !running && (
+        <ResultGallery
+          results={result}
+          zipName="split-image.zip"
+        />
+      )}
+    </div>
+  )
+}

--- a/src/operations/split-image/meta.js
+++ b/src/operations/split-image/meta.js
@@ -1,0 +1,8 @@
+export default {
+  id: 'split-image',
+  name: 'Split Image',
+  description: 'Split an image into a grid of tiles and download them as a ZIP.',
+  category: 'image',
+  icon: 'grid',
+  order: 42,
+}


### PR DESCRIPTION
Closes #154

**What changed**
- Added a new Split Image operation using the DoxDock plugin architecture.
- Added rows and columns controls to split an image into tiles.
- Uses DoxDock's shared imageCanvas helpers for local image processing.
- Returns individual PNG tiles through ResultGallery.
- Tiles can be downloaded together as a single ZIP.
- Runs fully offline with no network calls or external assets.

**Acceptance criteria**
- [x] An image splits into rows × columns tiles.
- [x] Tiles download as a single ZIP.
- [x] Runs fully offline.

**Proof**
- Tested a 2 × 2 split and verified all 4 tiles.
- Tested a 3 × 2 split and verified all 6 tiles.
- Verified the downloaded ZIP contains all generated tiles.
- Tested while offline successfully.
- `npm run build` passes successfully.