### PR TITLE
docs: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report something that is not working
+title: ''
+labels: bug
+assignees: ''
+---
+
+### What happened
+A clear description of the bug.
+
+### Steps to reproduce
+1. Go to '...'
+2. Upload '...'
+3. Click '...'
+4. See the error
+
+### What you expected
+A clear description of what you expected to happen.
+
+### Screenshots
+If it helps, add screenshots.
+
+### Environment
+- Tool: (e.g. Merge PDFs)
+- Browser and version: (e.g. Chrome 130)
+- Platform: (e.g. macOS, Windows, Android)
+- DoxDock: web app or Chrome extension
+
+### Anything else
+Add any other context here. Please do not attach any private or sensitive files.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/mithun-srinivas/DoxDock/discussions
+    about: Ask a question or share an idea with the community.
+  - name: Report a security issue
+    url: https://github.com/mithun-srinivas/DoxDock/security/policy
+    about: Please report vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature or new tool
+about: Suggest a new tool or an improvement to an existing one
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+### Short Description
+A clear, one or two sentence description of the tool or improvement.
+
+### Scope
+- If it is a new tool, follow the plugin pattern: a self-contained `src/operations/<id>/{meta.js,index.jsx,helpers.js}` folder (auto-discovered, no central wiring), reusing shared pieces (Dropzone, useJob, Note, Progress, ResultGallery/ImageResult, imageCanvas).
+- Describe the approach and which shared helpers or libraries it should use.
+- Must stay 100% client-side: no network calls, no CDNs, no external assets (respect the strict CSP `connect-src 'self'` in `index.html`).
+
+### Acceptance criteria
+- [ ] ...
+- [ ] ...
+- [ ] Runs fully offline.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Thanks for contributing to DoxDock! Please fill this in so the PR is easy to review. -->
+
+### Which issue does this close?
+<!-- Tag it like "Closes #12" so it links and auto-closes the issue when merged. -->
+Closes #
+
+### What changed
+<!-- A short, plain explanation of what you did and why. -->
+
+### Acceptance criteria
+<!-- Copy the checklist from the issue and tick off each item you have met. -->
+- [ ] ...
+- [ ] ...
+
+### Checklist
+- [ ] Runs fully offline: no network calls, no CDNs, no external assets (strict CSP `connect-src 'self'`).
+- [ ] Follows the plugin pattern and reuses shared components where relevant.
+- [ ] `npm run build` passes locally.
+
+### Proof
+<!-- Briefly, how did you test it? Screenshots welcome. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**mithunsrinivasappa@gmail.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+DoxDock is built around a simple promise: your files never leave your device.
+The app runs 100% in your browser, enforced by a strict Content Security Policy
+(`connect-src 'self'`) so there are no uploads, no servers, and no third-party
+network calls. Keeping that guarantee intact is our top security priority.
+
+## Supported versions
+
+DoxDock is a continuously deployed web app and Chrome extension. Security fixes
+are always applied to the latest release, which is the only supported version.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release | Yes |
+| Older releases | No |
+
+## Reporting a vulnerability
+
+Please report security issues privately. Do not open a public issue for a
+vulnerability.
+
+You can report in either of these ways:
+
+1. **GitHub private advisory (preferred):** open a report at
+   https://github.com/mithun-srinivas/DoxDock/security/advisories/new
+2. **Email:** send details to **mithunsrinivasappa@gmail.com**.
+
+Please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce, or a proof of concept.
+- The affected version, browser, and platform if relevant.
+
+## What to expect
+
+- We aim to acknowledge your report within 3 days.
+- We will keep you updated as we investigate and work on a fix.
+- Once a fix is released, we are happy to credit you in the release notes unless
+  you prefer to stay anonymous.
+
+## Scope
+
+Things we especially care about:
+
+- Anything that could cause a user's file or data to leave their device.
+- Ways to bypass the Content Security Policy or make an unexpected network
+  request.
+- Cross-site scripting or code injection in any tool.
+
+Thanks for helping keep DoxDock safe and private for everyone.


### PR DESCRIPTION
Adds the four community health files GitHub flags as missing, so the Community Standards checklist is complete.

- CODE_OF_CONDUCT.md (Contributor Covenant 2.1)
- SECURITY.md (private reporting, no-upload guarantee restated)
- Issue templates (bug report, feature/new tool matching our issue format, plus config with discussion and security links)
- Pull request template (matches the CONTRIBUTING guidance)

Docs only, no code changes.