### PR TITLE
feat: add grayscale-pdf operation

### DIFF
--- a/src/operations/grayscale-pdf/helpers.js
+++ b/src/operations/grayscale-pdf/helpers.js
@@ -12,27 +12,34 @@ import { loadPdf } from '../../lib/pdfjs.js'
 // "convert every page to grayscale" as specified.
 
 /**
- * Desaturate in place. The canvas filter does the work where supported; the
- * manual ITU-R BT.601 luminance loop is the fallback for engines without
- * canvas filters.
+ * Desaturate a rendered page canvas. Returns a NEW canvas holding the gray
+ * result: the source is drawn onto a filtered second canvas (same approach as
+ * the greyscale-image operation), never wiped or self-drawn. The manual
+ * ITU-R BT.601 luminance loop is the fallback for engines without canvas
+ * filters; it reads the rendered pixels from the source and writes them,
+ * grayscaled, into the new canvas.
  */
 function desaturate(canvas) {
-  const ctx = canvas.getContext('2d')
-  ctx.fillStyle = '#ffffff'
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  const out = document.createElement('canvas')
+  out.width = canvas.width
+  out.height = canvas.height
+  const ctx = out.getContext('2d')
   if (typeof ctx.filter === 'string') {
     ctx.filter = 'grayscale(1)'
     ctx.drawImage(canvas, 0, 0)
-    ctx.filter = 'none'
-    return
+    return out
   }
-  const image = ctx.getImageData(0, 0, canvas.width, canvas.height)
-  const px = image.data
-  for (let i = 0; i < px.length; i += 4) {
-    const gray = 0.299 * px[i] + 0.587 * px[i + 1] + 0.114 * px[i + 2]
-    px[i] = px[i + 1] = px[i + 2] = gray
+  const src = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height)
+  const dst = ctx.createImageData(canvas.width, canvas.height)
+  const s = src.data
+  const d = dst.data
+  for (let i = 0; i < s.length; i += 4) {
+    const gray = 0.299 * s[i] + 0.587 * s[i + 1] + 0.114 * s[i + 2]
+    d[i] = d[i + 1] = d[i + 2] = gray
+    d[i + 3] = s[i + 3]
   }
-  ctx.putImageData(image, 0, 0)
+  ctx.putImageData(dst, 0, 0)
+  return out
 }
 
 /** Canvas → JPEG bytes (grayscale-safe: no alpha to composite). */
@@ -104,8 +111,8 @@ export async function grayscalePdf(file, onProgress) {
       background: '#ffffff',
     }).promise
 
-    desaturate(canvas)
-    const jpg = await canvasToJpegBytes(canvas)
+    const grayCanvas = desaturate(canvas)
+    const jpg = await canvasToJpegBytes(grayCanvas)
     const image = await out.embedJpg(jpg)
 
     const pdfPage = out.addPage([width, height])

--- a/src/operations/grayscale-pdf/helpers.js
+++ b/src/operations/grayscale-pdf/helpers.js
@@ -1,0 +1,126 @@
+import { PDFDocument } from 'pdf-lib'
+import { loadPdf } from '../../lib/pdfjs.js'
+
+// Grayscale conversion happens at the canvas level, exactly like the image
+// operation: pdf.js paints the page, `ctx.filter = 'grayscale(1)'` (or a
+// manual luminance pass for the JPEG path) desaturates the pixels, and
+// pdf-lib rebuilds a fresh document from the page images.
+//
+// Rasterizing is the honest trade here: it makes the output uniform (every
+// viewer shows the same gray), drops any color-embedded profile, and keeps us
+// 100% offline. The cost — selectable text becomes pixels — is inherent to
+// "convert every page to grayscale" as specified.
+
+/**
+ * Desaturate in place. The canvas filter does the work where supported; the
+ * manual ITU-R BT.601 luminance loop is the fallback for engines without
+ * canvas filters.
+ */
+function desaturate(canvas) {
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  if (typeof ctx.filter === 'string') {
+    ctx.filter = 'grayscale(1)'
+    ctx.drawImage(canvas, 0, 0)
+    ctx.filter = 'none'
+    return
+  }
+  const image = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  const px = image.data
+  for (let i = 0; i < px.length; i += 4) {
+    const gray = 0.299 * px[i] + 0.587 * px[i + 1] + 0.114 * px[i + 2]
+    px[i] = px[i + 1] = px[i + 2] = gray
+  }
+  ctx.putImageData(image, 0, 0)
+}
+
+/** Canvas → JPEG bytes (grayscale-safe: no alpha to composite). */
+async function canvasToJpegBytes(canvas) {
+  const blob = await new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('Canvas encoding failed.'))),
+      'image/jpeg',
+      0.92,
+    )
+  })
+  return new Uint8Array(await blob.arrayBuffer())
+}
+
+/**
+ * Convert every page of `file` to grayscale and rebuild the PDF.
+ *
+ * @param {File} file
+ * @param {(v:number,m:string)=>void} [onProgress]
+ * @returns {Promise<{blob:Blob, filename:string, before:number, after:number, pages:number}>}
+ */
+export async function grayscalePdf(file, onProgress) {
+  onProgress?.(0.05, 'Opening PDF…')
+  let data
+  try {
+    data = new Uint8Array(await file.arrayBuffer())
+  } catch {
+    throw new Error('Could not read this file.')
+  }
+
+  let pdf
+  try {
+    pdf = await loadPdf(data)
+  } catch {
+    throw new Error('Could not read this PDF. Encrypted PDFs are not supported.')
+  }
+
+  const total = pdf.numPages
+  if (!total) throw new Error('This PDF has no pages.')
+
+  // Page 1 fixes the output geometry so the rebuilt document stays uniform.
+  const first = await pdf.getPage(1)
+  const firstViewport = first.getViewport({ scale: 1 })
+  const width = Math.ceil(firstViewport.width)
+  const height = Math.ceil(firstViewport.height)
+
+  const out = await PDFDocument.create()
+  out.setProducer('DoxDock')
+  out.setCreator('DoxDock — grayscale-pdf')
+
+  for (let n = 1; n <= total; n++) {
+    onProgress?.(
+      0.1 + (n - 1) / total * 0.75,
+      `Converting page ${n} of ${total}…`,
+    )
+    const page = await pdf.getPage(n)
+    const scale = 2
+    const viewport = page.getViewport({ scale })
+    const canvas = document.createElement('canvas')
+    canvas.width = Math.ceil(viewport.width)
+    canvas.height = Math.ceil(viewport.height)
+
+    const ctx = canvas.getContext('2d')
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    await page.render({
+      canvasContext: ctx,
+      viewport,
+      background: '#ffffff',
+    }).promise
+
+    desaturate(canvas)
+    const jpg = await canvasToJpegBytes(canvas)
+    const image = await out.embedJpg(jpg)
+
+    const pdfPage = out.addPage([width, height])
+    pdfPage.drawImage(image, { x: 0, y: 0, width, height })
+  }
+
+  onProgress?.(0.92, 'Saving PDF…')
+  const bytes = await out.save()
+
+  onProgress?.(1, 'Done')
+  return {
+    blob: new Blob([bytes], { type: 'application/pdf' }),
+    filename: file.name.replace(/\.pdf$/i, '') + '-grayscale.pdf',
+    before: file.size,
+    after: bytes.length,
+    pages: total,
+  }
+}

--- a/src/operations/grayscale-pdf/index.jsx
+++ b/src/operations/grayscale-pdf/index.jsx
@@ -1,0 +1,53 @@
+import { useState } from "react"
+import Dropzone from "../../components/Dropzone.jsx"
+import Progress from "../../components/Progress.jsx"
+import Note from "../../components/Note.jsx"
+import DownloadButton from "../../components/DownloadButton.jsx"
+import Icon from "../../components/Icon.jsx"
+import { useJob } from "../../hooks/useJob.js"
+import { formatBytes } from "../../lib/format.js"
+import { grayscalePdf } from "./helpers.js"
+
+export default function GrayscalePdf() {
+    const [file, setFile] = useState(null)
+    const { running, progress, error, result, run, reset } = useJob()
+
+    const pick = (files) => {
+        setFile(files[0])
+        reset()
+    }
+    const go = () => run((p) => grayscalePdf(file, p))
+
+    return (
+        <div className="space-y-6">
+            <Dropzone onFiles={pick} accept="application/pdf,.pdf" multiple={false} label="Drop a PDF here or click to browse" icon="file" />
+
+            {file && (
+                <>
+                    <div className="card flex items-center gap-3 p-3">
+                        <Icon name="file" className="h-5 w-5 text-brand-600" />
+                        <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+                        <span className="text-xs text-slate-400">{formatBytes(file.size)}</span>
+                    </div>
+
+                    <button type="button" className="btn-primary" onClick={go} disabled={running}>
+                        <Icon name="contrast" className="h-4 w-4" />
+                        Convert to Grayscale
+                    </button>
+                </>
+            )}
+
+            {running && progress && <Progress value={progress.value} message={progress.message} />}
+            {error && <Note type="error" title="Conversion failed">{error}</Note>}
+            {result && !running && (
+                <>
+                    <DownloadButton result={result} />
+                    <Note type="info" title="Grayscale complete">
+                        {result.pages} page{result.pages === 1 ? '' : 's'} converted. Text is no
+                        longer selectable — pages are now grayscale images.
+                    </Note>
+                </>
+            )}
+        </div>
+    )
+}

--- a/src/operations/grayscale-pdf/meta.js
+++ b/src/operations/grayscale-pdf/meta.js
@@ -1,0 +1,8 @@
+export default {
+    id: 'grayscale-pdf',
+    name: 'Grayscale PDF',
+    description: 'Convert every page of a PDF to grayscale and download the result.',
+    category: 'pdf',
+    icon: 'contrast',
+    order: 23,
+}


### PR DESCRIPTION
## What

New self-contained operation `src/operations/grayscale-pdf/` (meta.js + index.jsx + helpers.js), every page of an input PDF is rendered with pdf.js at 2x scale, desaturated on-canvas, and a new PDF is rebuilt from the grayscale page images via pdf-lib.

Closes #169.

## How it works

- `lib/pdfjs.js` loader (bundled worker, zero network, CSP-safe)
- Desaturation mirrors `greyscale-image`: `ctx.filter = 'grayscale(1)'`, with a manual BT.601 luminance loop as fallback for engines without canvas filters
- Output geometry is normalized to page 1's size so the rebuilt document stays uniform
- Per-page progress; clear errors for encrypted or empty PDFs
- Honest tradeoff surfaced in the UI: pages become images, so text is no longer selectable

## Verification (executed locally)

- `npx vite build` → exit 0; the operation is auto-discovered and embedded in the bundle (`grayscale-pdf` present in dist assets)
- `npx eslint src/operations/grayscale-pdf/` → clean
- 100% client-side: no fetch/XHR added anywhere in the module
