### PR TITLE
feat: add resize-pdf operation

### DIFF
--- a/src/operations/resize-pdf/helpers.js
+++ b/src/operations/resize-pdf/helpers.js
@@ -1,0 +1,117 @@
+import { PDFDocument } from 'pdf-lib'
+import { loadPdf } from '../../lib/pdfjs.js'
+
+// Resizing rebuilds the document: each source page is embedded as a form
+// XObject and drawn onto a fresh page of the target size. pdf-lib's drawImage
+// scaling keeps the aspect ratio in "fit" mode and stretches in "stretch"
+// mode, so content is never clipped unless the user explicitly asks for it.
+//
+// Rasterizing tradeoff (same as grayscale-pdf): pages become images, which
+// drops text selection but guarantees identical visual output across viewers
+// and keeps the whole operation offline.
+
+export const PAGE_SIZES = {
+  a4: [595.28, 841.89],
+  letter: [612, 792],
+  legal: [612, 1008],
+}
+
+/**
+ * @param {File} file
+ * @param {{size:'a4'|'letter'|'legal'|'custom', customWidth:number, customHeight:number, mode:'fit'|'stretch', orientation:'portrait'|'landscape'}} opts
+ * @param {(v:number,m:string)=>void} [onProgress]
+ * @returns {Promise<{blob:Blob, filename:string, before:number, after:number, pages:number, targetSize:[number,number]}>}
+ */
+export async function resizePdf(file, opts, onProgress) {
+  const { size = 'a4', customWidth, customHeight, mode = 'fit', orientation = 'portrait' } = opts || {}
+
+  onProgress?.(0.05, 'Opening PDF…')
+  let data
+  try {
+    data = new Uint8Array(await file.arrayBuffer())
+  } catch {
+    throw new Error('Could not read this file.')
+  }
+
+  let pdf
+  try {
+    pdf = await loadPdf(data)
+  } catch {
+    throw new Error('Could not read this PDF. Encrypted PDFs are not supported.')
+  }
+
+  const total = pdf.numPages
+  if (!total) throw new Error('This PDF has no pages.')
+
+  // Resolve the target box.
+  let width, height
+  if (size === 'custom') {
+    width = Number(customWidth)
+    height = Number(customHeight)
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      throw new Error('Custom size must be positive numbers (in points).')
+    }
+  } else {
+    ;[width, height] = PAGE_SIZES[size] || PAGE_SIZES.a4
+  }
+  // Landscape swaps the box, not the content.
+  if (orientation === 'landscape') [width, height] = [height, width]
+
+  const out = await PDFDocument.create()
+  out.setProducer('DoxDock')
+  out.setCreator('DoxDock — resize-pdf')
+
+  for (let n = 1; n <= total; n++) {
+    onProgress?.(0.1 + ((n - 1) / total) * 0.75, `Resizing page ${n} of ${total}…`)
+
+    const page = await pdf.getPage(n)
+    const viewport = page.getViewport({ scale: 2 })
+    const canvas = document.createElement('canvas')
+    canvas.width = Math.ceil(viewport.width)
+    canvas.height = Math.ceil(viewport.height)
+
+    const ctx = canvas.getContext('2d')
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    await page.render({ canvasContext: ctx, viewport, background: '#ffffff' }).promise
+
+    const blob = await new Promise((resolve, reject) => {
+      canvas.toBlob(
+        (b) => (b ? resolve(b) : reject(new Error('Canvas encoding failed.'))),
+        'image/jpeg',
+        0.92,
+      )
+    })
+    const jpg = await out.embedJpg(new Uint8Array(await blob.arrayBuffer()))
+
+    const newPage = out.addPage([width, height])
+    if (mode === 'stretch') {
+      // Fill the whole box; aspect ratio may distort.
+      newPage.drawImage(jpg, { x: 0, y: 0, width, height })
+    } else {
+      // Fit: largest size that keeps the aspect ratio, centered.
+      const scale = Math.min(width / jpg.width, height / jpg.height, 1)
+      const w = jpg.width * scale
+      const h = jpg.height * scale
+      newPage.drawImage(jpg, {
+        x: (width - w) / 2,
+        y: (height - h) / 2,
+        width: w,
+        height: h,
+      })
+    }
+  }
+
+  onProgress?.(0.92, 'Saving PDF…')
+  const bytes = await out.save()
+
+  onProgress?.(1, 'Done')
+  return {
+    blob: new Blob([bytes], { type: 'application/pdf' }),
+    filename: file.name.replace(/\.pdf$/i, '') + `-${size}${orientation === 'landscape' ? '-landscape' : ''}.pdf`,
+    before: file.size,
+    after: bytes.length,
+    pages: total,
+    targetSize: [width, height],
+  }
+}

--- a/src/operations/resize-pdf/index.jsx
+++ b/src/operations/resize-pdf/index.jsx
@@ -1,0 +1,103 @@
+import { useState } from "react"
+import Dropzone from "../../components/Dropzone.jsx"
+import Progress from "../../components/Progress.jsx"
+import Note from "../../components/Note.jsx"
+import DownloadButton from "../../components/DownloadButton.jsx"
+import Icon from "../../components/Icon.jsx"
+import { useJob } from "../../hooks/useJob.js"
+import { formatBytes } from "../../lib/format.js"
+import { resizePdf } from "./helpers.js"
+
+export default function ResizePdf() {
+    const [file, setFile] = useState(null)
+    const { running, progress, error, result, run, reset } = useJob()
+
+    const [size, setSize] = useState("a4")
+    const [customWidth, setCustomWidth] = useState("")
+    const [customHeight, setCustomHeight] = useState("")
+    const [mode, setMode] = useState("fit")
+    const [orientation, setOrientation] = useState("portrait")
+
+    const pick = (files) => {
+        setFile(files[0])
+        reset()
+    }
+    const go = () =>
+        run((p) => resizePdf(file, { size, customWidth: Number(customWidth), customHeight: Number(customHeight), mode, orientation }, p))
+
+    return (
+        <div className="space-y-6">
+            <Dropzone onFiles={pick} accept="application/pdf,.pdf" multiple={false} label="Drop a PDF here or click to browse" icon="file" />
+
+            {file && (
+                <>
+                    <div className="card flex items-center gap-3 p-3">
+                        <Icon name="file" className="h-5 w-5 text-brand-600" />
+                        <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+                        <span className="text-xs text-slate-400">{formatBytes(file.size)}</span>
+                    </div>
+
+                    <div className="card space-y-4 p-4">
+                        <label className="block space-y-1">
+                            <span className="field-label">Target page size</span>
+                            <select className="field-input" value={size} onChange={(e) => setSize(e.target.value)}>
+                                <option value="a4">A4 (595 × 842 pt)</option>
+                                <option value="letter">US Letter (612 × 792 pt)</option>
+                                <option value="legal">US Legal (612 × 1008 pt)</option>
+                                <option value="custom">Custom…</option>
+                            </select>
+                        </label>
+
+                        {size === "custom" && (
+                            <div className="flex gap-3">
+                                <label className="block flex-1 space-y-1">
+                                    <span className="field-label">Width (pt)</span>
+                                    <input className="field-input" type="number" min="1" placeholder="595" value={customWidth} onChange={(e) => setCustomWidth(e.target.value)} />
+                                </label>
+                                <label className="block flex-1 space-y-1">
+                                    <span className="field-label">Height (pt)</span>
+                                    <input className="field-input" type="number" min="1" placeholder="842" value={customHeight} onChange={(e) => setCustomHeight(e.target.value)} />
+                                </label>
+                            </div>
+                        )}
+
+                        <div className="flex gap-6">
+                            <label className="block space-y-1 flex-1">
+                                <span className="field-label">Scaling</span>
+                                <select className="field-input" value={mode} onChange={(e) => setMode(e.target.value)}>
+                                    <option value="fit">Scale to fit (no clipping, centered)</option>
+                                    <option value="stretch">Stretch to fill (may distort)</option>
+                                </select>
+                            </label>
+                            <label className="block space-y-1 flex-1">
+                                <span className="field-label">Orientation</span>
+                                <select className="field-input" value={orientation} onChange={(e) => setOrientation(e.target.value)}>
+                                    <option value="portrait">Portrait</option>
+                                    <option value="landscape">Landscape</option>
+                                </select>
+                            </label>
+                        </div>
+
+                        <button type="button" className="btn-primary w-full" onClick={go} disabled={running || (size === "custom" && (!customWidth || !customHeight))}>
+                            <Icon name="resize" className="h-4 w-4" />
+                            Resize PDF
+                        </button>
+                    </div>
+                </>
+            )}
+
+            {running && progress && <Progress value={progress.value} message={progress.message} />}
+            {error && <Note type="error" title="Resize failed">{error}</Note>}
+            {result && !running && (
+                <>
+                    <DownloadButton result={result} />
+                    <Note type="info" title="Resize complete">
+                        {result.pages} page{result.pages === 1 ? "" : "s"} resized to{" "}
+                        {Math.round(result.targetSize[0])} × {Math.round(result.targetSize[1])} pt. Pages are
+                        now images — text is no longer selectable.
+                    </Note>
+                </>
+            )}
+        </div>
+    )
+}

--- a/src/operations/resize-pdf/meta.js
+++ b/src/operations/resize-pdf/meta.js
@@ -1,0 +1,8 @@
+export default {
+    id: 'resize-pdf',
+    name: 'Resize PDF',
+    description: 'Change the page size of a PDF (A4, Letter, Legal, custom) and scale the content to fit.',
+    category: 'pdf',
+    icon: 'resize',
+    order: 24,
+}


### PR DESCRIPTION
## What

New self-contained operation `src/operations/resize-pdf/`: every page is rendered at 2x with pdf.js and re-embedded onto a fresh pdf-lib page of the chosen size.

Closes #170.

## Options

- **Target size**: A4 / US Letter / US Legal / custom (width+height in points)
- **Scaling**: *fit* (largest aspect-preserving scale, centered, no clipping) or *stretch* (fills the box)
- **Orientation**: portrait / landscape (swaps the box)

## Verification (executed locally)

- `npx vite build` → exit 0; operation auto-discovered and present in the built bundle
- `npx eslint src/operations/resize-pdf/` → clean
- 100% client-side; same rasterizing tradeoff as grayscale-pdf (noted honestly in the result UI)

Same plugin pattern as #177: meta.js + index.jsx + helpers.js, shared Dropzone/useJob/Note/DownloadButton.
