### PR TITLE
feat: add every-N-pages split mode

### DIFF
--- a/src/operations/split-pdf/helpers.js
+++ b/src/operations/split-pdf/helpers.js
@@ -80,7 +80,7 @@ function topLevelBookmarks(src) {
  * @returns {Promise<{filename:string, blob:Blob}[]>}
  */
 export async function splitPdf(file, opts, onProgress) {
-  const { mode = 'explode', ranges = '', sizeMb = 5 } = opts || {}
+  const { mode = 'explode', ranges = '', sizeMb = 5, everyN = 2 } = opts || {}
   let src
   try {
     src = await PDFDocument.load(await file.arrayBuffer())
@@ -114,6 +114,19 @@ export async function splitPdf(file, opts, onProgress) {
       const blob = await subsetPdf(src, pageIndices)
       const slug = (bookmarks[b].title || `chapter-${b + 1}`).replace(/[^\w-]+/g, '_').slice(0, 60)
       results.push({ filename: `${base}-${String(b + 1).padStart(2, '0')}-${slug}.pdf`, blob })
+    }
+  } else if (mode === 'everyN') {
+    const n = Math.floor(Number(everyN))
+    if (!Number.isFinite(n) || n < 1) throw new Error('Pages per file must be a whole number of 1 or more.')
+    const groups = []
+    for (let i = 0; i < total; i += n) groups.push(Array.from({ length: Math.min(n, total - i) }, (_, k) => i + k))
+    for (let g = 0; g < groups.length; g++) {
+      onProgress?.(g / groups.length, `Building file ${g + 1} of ${groups.length}…`)
+      const blob = await subsetPdf(src, groups[g])
+      const first = groups[g][0] + 1
+      const last = groups[g][groups[g].length - 1] + 1
+      const span = first === last ? `page${first}` : `pages${first}-${last}`
+      results.push({ filename: `${base}-${span}.pdf`, blob })
     }
   } else if (mode === 'explode') {
     for (let i = 0; i < total; i++) {

--- a/src/operations/split-pdf/index.jsx
+++ b/src/operations/split-pdf/index.jsx
@@ -14,6 +14,7 @@ export default function SplitPdf() {
   const [mode, setMode] = useState('explode')
   const [ranges, setRanges] = useState('')
   const [sizeMb, setSizeMb] = useState(5)
+  const [everyN, setEveryN] = useState(2)
   const { running, progress, error, result, run, reset } = useJob()
   const { pageCount } = usePdfPageCount(file)
 
@@ -38,7 +39,7 @@ export default function SplitPdf() {
     setFile(files[0])
     reset()
   }
-  const go = () => run((p) => splitPdf(file, { mode, ranges, sizeMb }, p))
+  const go = () => run((p) => splitPdf(file, { mode, ranges, sizeMb, everyN }, p))
 
   return (
     <div className="space-y-6">
@@ -68,10 +69,32 @@ export default function SplitPdf() {
                 By size — pack pages so each PDF stays under a target
               </label>
               <label className="flex items-center gap-2 text-sm">
+                <input type="radio" name="mode" checked={mode === 'everyN'} onChange={() => setMode('everyN')} />
+                Every N pages — fixed-size chunks
+              </label>
+              <label className="flex items-center gap-2 text-sm">
                 <input type="radio" name="mode" checked={mode === 'bookmarks'} onChange={() => setMode('bookmarks')} />
                 By bookmarks — one PDF per top-level bookmark (chapter)
               </label>
             </fieldset>
+            {mode === 'everyN' && (
+              <label className="block space-y-1">
+                <span className="field-label">Pages per file</span>
+                <input
+                  className="field-input"
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={everyN}
+                  onChange={(e) => setEveryN(e.target.value)}
+                />
+                {pageCount != null && Number(everyN) >= 1 && (
+                  <span className="text-xs text-slate-500">
+                    {pageCount} pages → {Math.ceil(pageCount / Number(everyN))} file{Math.ceil(pageCount / Number(everyN)) === 1 ? '' : 's'} (last one may be smaller).
+                  </span>
+                )}
+              </label>
+            )}
             {mode === 'size' && (
               <label className="block space-y-1">
                 <span className="field-label">Target size per file (MB)</span>


### PR DESCRIPTION
## What

Closes #171: adds the **every N pages** split mode to the existing Split PDF tool.

## Context

Investigating before building: the tool already shipped **by size** and **by bookmarks** modes, so the only gap from the issue's list was fixed-size chunks. This PR adds exactly that, keeping the plugin pattern and the tool's existing UI conventions.

## How

- New `everyN` mode: chunks of N pages, last one smaller when the page count isn't divisible
- Live preview while typing: "7 pages → 3 files (last one may be smaller)"
- Descriptive filenames: `base-pages1-3.pdf`, and `base-page7.pdf` (singular) for a single-page tail
- Invalid N (non-numeric or < 1) fails with a clear message before any work starts

## Verification

Generated a real 7-page PDF and ran it through the actual helper code:
- N=3 → exactly 3 files (`pages1-3`, `pages4-6`, `page7`), sub-PDF page counts asserted (3/3/1)
- N=1 → 7 files (explode-equivalent); N=10 → 1 file covering the whole document
- N=0 rejected with a clear error
- `eslint` clean, `vite build` exit 0, Playwright suite **5/5** locally