### PR TITLE
feat: add favicon and app icon generator

### DIFF
--- a/src/operations/favicon/helpers.js
+++ b/src/operations/favicon/helpers.js
@@ -1,0 +1,185 @@
+import { decode, dimsOf, drawToCanvas, canvasToBlob } from '../../lib/imageCanvas.js'
+
+const SIZES = [16, 32, 48, 180, 192, 512]
+
+function getCenterCrop(width, height) {
+  if (width === height) {
+    return {
+      x: 0,
+      y: 0,
+      w: width,
+      h: height,
+    }
+  }
+
+  if (width > height) {
+    return {
+      x: (width - height) / 2,
+      y: 0,
+      w: height,
+      h: height,
+    }
+  }
+
+  return {
+    x: 0,
+    y: (height - width) / 2,
+    w: width,
+    h: width,
+  }
+}
+
+async function createIcon(bitmap, size) {
+  const { width, height } = dimsOf(bitmap)
+
+  const crop = getCenterCrop(width, height)
+
+  const canvas = drawToCanvas(bitmap, {
+    width: size,
+    height: size,
+    crop,
+  })
+
+  return canvasToBlob(canvas, 'png')
+}
+
+/**
+ * Create a multi-size ICO containing PNG images.
+ *
+ * ICO traditionally stores the small favicon sizes, so we include
+ * 16x16, 32x32 and 48x48 here.
+ */
+async function createIco(images) {
+  const icoImages = images.filter(({ size }) => size <= 48)
+
+  const headerSize = 6
+  const directoryEntrySize = 16
+  const directorySize = icoImages.length * directoryEntrySize
+
+  let offset = headerSize + directorySize
+
+  const imageData = []
+
+  for (const image of icoImages) {
+    const bytes = new Uint8Array(await image.blob.arrayBuffer())
+
+    imageData.push({
+      size: image.size,
+      bytes,
+      offset,
+    })
+
+    offset += bytes.length
+  }
+
+  const buffer = new ArrayBuffer(offset)
+  const view = new DataView(buffer)
+
+  // ICO header
+  view.setUint16(0, 0, true) // reserved
+  view.setUint16(2, 1, true) // image type
+  view.setUint16(4, imageData.length, true) // number of images
+
+  let directoryOffset = headerSize
+
+  for (const image of imageData) {
+    const size = image.size
+
+    // 0 means 256px in ICO format.
+    view.setUint8(directoryOffset, size >= 256 ? 0 : size)
+    view.setUint8(directoryOffset + 1, size >= 256 ? 0 : size)
+
+    // Color palette count.
+    view.setUint8(directoryOffset + 2, 0)
+
+    // Reserved.
+    view.setUint8(directoryOffset + 3, 0)
+
+    // Color planes.
+    view.setUint16(directoryOffset + 4, 1, true)
+
+    // Bits per pixel.
+    view.setUint16(directoryOffset + 6, 32, true)
+
+    // Image data size.
+    view.setUint32(directoryOffset + 8, image.bytes.length, true)
+
+    // Offset to image data.
+    view.setUint32(directoryOffset + 12, image.offset, true)
+
+    directoryOffset += directoryEntrySize
+  }
+
+  const output = new Uint8Array(buffer)
+
+  for (const image of imageData) {
+    output.set(image.bytes, image.offset)
+  }
+
+  return new Blob([output], {
+    type: 'image/x-icon',
+  })
+}
+
+/**
+ * Generate all favicon/app-icon files from one image.
+ *
+ * @param {File} file
+ * @param {(value:number, message:string) => void} onProgress
+ */
+export async function generateFavicons(file, onProgress) {
+  if (!file?.type?.startsWith('image/')) {
+    throw new Error('Please choose an image file.')
+  }
+
+  onProgress?.(0.05, 'Decoding image…')
+
+  const bitmap = await decode(file)
+
+  try {
+    const results = []
+    const icoImages = []
+
+    for (let i = 0; i < SIZES.length; i += 1) {
+      const size = SIZES[i]
+
+      const progress = 0.1 + (i / SIZES.length) * 0.75
+
+      onProgress?.(
+        progress,
+        `Generating ${size}×${size} icon…`,
+      )
+
+      const blob = await createIcon(bitmap, size)
+
+      const result = {
+        blob,
+        filename: `icon-${size}x${size}.png`,
+      }
+
+      results.push(result)
+
+      if (size <= 48) {
+        icoImages.push({
+          size,
+          blob,
+        })
+      }
+    }
+
+    onProgress?.(0.9, 'Creating favicon.ico…')
+
+    const icoBlob = await createIco(icoImages)
+
+    results.push({
+      blob: icoBlob,
+      filename: 'favicon.ico',
+    })
+
+    onProgress?.(1, 'Done')
+
+    return results
+  } finally {
+    bitmap.close?.()
+  }
+}

--- a/src/operations/favicon/index.jsx
+++ b/src/operations/favicon/index.jsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import ResultGallery from '../../components/ResultGallery.jsx'
+
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes } from '../../lib/format.js'
+
+import { generateFavicons } from './helpers.js'
+
+export default function FaviconGenerator() {
+  const [file, setFile] = useState(null)
+
+  const {
+    running,
+    progress,
+    error,
+    result,
+    run,
+    reset,
+  } = useJob()
+
+  const pick = (files) => {
+    setFile(files[0])
+    reset()
+  }
+
+  const go = () => {
+    run((onProgress) => generateFavicons(file, onProgress))
+  }
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        accept="image/*"
+        multiple={false}
+        label="Drop an image here or click to browse"
+        hint="JPEG, PNG, WebP, or AVIF"
+        icon="image"
+      />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon
+              name="image"
+              className="h-5 w-5 text-brand-600"
+            />
+
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+              {file.name}
+            </span>
+
+            <span className="text-xs text-slate-400">
+              {formatBytes(file.size)}
+            </span>
+          </div>
+
+          <Note type="info">
+            Generates 16×16, 32×32, 48×48, 180×180, 192×192,
+            and 512×512 PNG icons, plus a multi-size favicon.ico.
+          </Note>
+
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={go}
+            disabled={running}
+          >
+            <Icon
+              name="image"
+              className="h-4 w-4"
+            />
+            Generate Icons
+          </button>
+        </>
+      )}
+
+      {running && progress && (
+        <Progress
+          value={progress.value}
+          message={progress.message}
+        />
+      )}
+
+      {error && (
+        <Note
+          type="error"
+          title="Icon generation failed"
+        >
+          {error}
+        </Note>
+      )}
+
+      {result && !running && (
+        <ResultGallery
+          results={result}
+          zipName="favicon-icons.zip"
+          preview
+        />
+      )}
+    </div>
+  )
+}

--- a/src/operations/favicon/meta.js
+++ b/src/operations/favicon/meta.js
@@ -1,0 +1,8 @@
+export default {
+  id: 'favicon',
+  name: 'Favicon / App Icon Generator',
+  description: 'Generate standard favicon and app icon sizes plus a multi-size ICO from one image.',
+  category: 'image',
+  icon: 'image',
+  order: 25,
+}


### PR DESCRIPTION
## Summary

Adds a new Favicon / App Icon Generator operation.

### What it does

* Generates 16×16, 32×32, and 48×48 favicon PNGs
* Generates 180×180, 192×192, and 512×512 app icons
* Generates a multi-size `favicon.ico`
* Supports downloading all generated files as a single ZIP
* Processes images entirely client-side
* Reuses DoxDock's existing image canvas and result gallery utilities
* Preserves image aspect ratio using a centered square crop

### Testing

* Tested with PNG/JPEG images
* Tested generated icon sizes
* Tested `favicon.ico`
* Tested ZIP download
* Tested the operation in the browser
* `npm run build` passes successfully

Closes #152
