### PR TITLE
feat: add color palette extractor

### DIFF
--- a/src/operations/palette/helpers.js
+++ b/src/operations/palette/helpers.js
@@ -7,10 +7,6 @@ const DEFAULT_COLORS = 6
 const SAMPLE_SIZE = 100000
 const BUCKET_SIZE = 32
 
-function clamp(value, min, max) {
-  return Math.max(min, Math.min(max, value))
-}
-
 function toHex(value) {
   return value.toString(16).padStart(2, '0').toUpperCase()
 }
@@ -27,14 +23,6 @@ function colorInfo(r, g, b) {
 
 function quantize(value) {
   return Math.floor(value / BUCKET_SIZE)
-}
-
-function representative(value) {
-  return clamp(
-    value * BUCKET_SIZE + Math.floor(BUCKET_SIZE / 2),
-    0,
-    255,
-  )
 }
 
 function getSampleStep(width, height) {
@@ -58,7 +46,6 @@ function distanceSquared(a, b) {
 function extractBuckets(imageData, width, height, onProgress) {
   const buckets = new Map()
   const step = getSampleStep(width, height)
-  const totalRows = Math.ceil(height / step)
 
   for (let y = 0; y < height; y += step) {
     for (let x = 0; x < width; x += step) {

--- a/src/operations/palette/helpers.js
+++ b/src/operations/palette/helpers.js
@@ -1,0 +1,215 @@
+import { decode, dimsOf } from '../../lib/imageCanvas.js'
+
+const MIN_COLORS = 3
+const MAX_COLORS = 12
+const DEFAULT_COLORS = 6
+
+const SAMPLE_SIZE = 100000
+const BUCKET_SIZE = 32
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value))
+}
+
+function toHex(value) {
+  return value.toString(16).padStart(2, '0').toUpperCase()
+}
+
+function colorInfo(r, g, b) {
+  return {
+    r,
+    g,
+    b,
+    hex: `#${toHex(r)}${toHex(g)}${toHex(b)}`,
+    rgb: `rgb(${r}, ${g}, ${b})`,
+  }
+}
+
+function quantize(value) {
+  return Math.floor(value / BUCKET_SIZE)
+}
+
+function representative(value) {
+  return clamp(
+    value * BUCKET_SIZE + Math.floor(BUCKET_SIZE / 2),
+    0,
+    255,
+  )
+}
+
+function getSampleStep(width, height) {
+  const totalPixels = width * height
+
+  if (totalPixels <= SAMPLE_SIZE) {
+    return 1
+  }
+
+  return Math.ceil(Math.sqrt(totalPixels / SAMPLE_SIZE))
+}
+
+function distanceSquared(a, b) {
+  const dr = a.r - b.r
+  const dg = a.g - b.g
+  const db = a.b - b.b
+
+  return dr * dr + dg * dg + db * db
+}
+
+function extractBuckets(imageData, width, height, onProgress) {
+  const buckets = new Map()
+  const step = getSampleStep(width, height)
+  const totalRows = Math.ceil(height / step)
+
+  for (let y = 0; y < height; y += step) {
+    for (let x = 0; x < width; x += step) {
+      const index = (y * width + x) * 4
+
+      const alpha = imageData[index + 3]
+
+      if (alpha < 32) {
+        continue
+      }
+
+      const r = imageData[index]
+      const g = imageData[index + 1]
+      const b = imageData[index + 2]
+
+      const key = `${quantize(r)},${quantize(g)},${quantize(b)}`
+      const bucket = buckets.get(key)
+
+      if (bucket) {
+        bucket.count += 1
+        bucket.r += r
+        bucket.g += g
+        bucket.b += b
+      } else {
+        buckets.set(key, {
+          count: 1,
+          r,
+          g,
+          b,
+        })
+      }
+    }
+
+    onProgress?.(
+      0.1 + (y / Math.max(1, height)) * 0.55,
+      'Analyzing image...',
+    )
+  }
+
+  return Array.from(buckets.values())
+    .map((bucket) => ({
+      count: bucket.count,
+      color: colorInfo(
+        Math.round(bucket.r / bucket.count),
+        Math.round(bucket.g / bucket.count),
+        Math.round(bucket.b / bucket.count),
+      ),
+    }))
+    .sort((a, b) => b.count - a.count)
+}
+
+function selectColors(buckets, count) {
+  const selected = []
+
+  for (const bucket of buckets) {
+    if (selected.length >= count) {
+      break
+    }
+
+    const isTooClose = selected.some(
+      (color) => distanceSquared(color, bucket.color) < 900,
+    )
+
+    if (!isTooClose) {
+      selected.push(bucket.color)
+    }
+  }
+
+  for (const bucket of buckets) {
+    if (selected.length >= count) {
+      break
+    }
+
+    if (!selected.includes(bucket.color)) {
+      selected.push(bucket.color)
+    }
+  }
+
+  return selected
+}
+
+/**
+ * Extract dominant colors from an image.
+ *
+ * @param {File} file
+ * @param {{count?: number}} opts
+ * @param {(value:number, message:string) => void} onProgress
+ */
+export async function extractPalette(file, opts, onProgress) {
+  if (!file?.type?.startsWith('image/')) {
+    throw new Error('Please choose an image file.')
+  }
+
+  const count = Math.round(
+    Number(opts?.count) || DEFAULT_COLORS,
+  )
+
+  if (!Number.isInteger(count) || count < MIN_COLORS || count > MAX_COLORS) {
+    throw new Error(
+      `Number of colors must be a whole number between ${MIN_COLORS} and ${MAX_COLORS}.`,
+    )
+  }
+
+  onProgress?.(0.05, 'Decoding image...')
+
+  const bitmap = await decode(file)
+
+  try {
+    const { width, height } = dimsOf(bitmap)
+
+    if (!width || !height) {
+      throw new Error('Could not determine the image dimensions.')
+    }
+
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+
+    const ctx = canvas.getContext('2d', {
+      willReadFrequently: true,
+    })
+
+    if (!ctx) {
+      throw new Error('Could not prepare the image for color analysis.')
+    }
+
+    ctx.drawImage(bitmap, 0, 0)
+
+    onProgress?.(0.1, 'Reading image colors...')
+
+    const { data } = ctx.getImageData(0, 0, width, height)
+
+    const buckets = extractBuckets(
+      data,
+      width,
+      height,
+      onProgress,
+    )
+
+    if (buckets.length === 0) {
+      throw new Error('No visible colors were found in this image.')
+    }
+
+    onProgress?.(0.75, 'Selecting dominant colors...')
+
+    const colors = selectColors(buckets, count)
+
+    onProgress?.(1, 'Done')
+
+    return colors
+  } finally {
+    bitmap.close?.()
+  }
+}

--- a/src/operations/palette/index.jsx
+++ b/src/operations/palette/index.jsx
@@ -1,0 +1,204 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes } from '../../lib/format.js'
+import { IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
+import { extractPalette } from './helpers.js'
+
+const MIN_COLORS = 3
+const MAX_COLORS = 12
+
+export default function PaletteExtractor() {
+  const [file, setFile] = useState(null)
+  const [count, setCount] = useState(6)
+  const [copied, setCopied] = useState(null)
+
+  const {
+    running,
+    progress,
+    error,
+    result,
+    run,
+    reset,
+  } = useJob()
+
+  const pick = (files) => {
+    setFile(files[0] || null)
+    setCopied(null)
+    reset()
+  }
+
+  const go = () => {
+    if (!file) return
+
+    setCopied(null)
+
+    run((onProgress) =>
+      extractPalette(
+        file,
+        { count: Number(count) },
+        onProgress,
+      ),
+    )
+  }
+
+  const copyColor = async (color) => {
+    try {
+      await navigator.clipboard.writeText(color.hex)
+      setCopied(color.hex)
+
+      setTimeout(() => {
+        setCopied(null)
+      }, 2000)
+    } catch {
+      setCopied(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        files={file ? [file] : []}
+        accept="image/*"
+        multiple={false}
+        label="Drop an image here or click to browse"
+        hint={IMAGE_FORMATS_HINT}
+        icon="image"
+      />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon
+              name="image"
+              className="h-5 w-5 text-brand-600"
+            />
+
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+              {file.name}
+            </span>
+
+            <span className="text-xs text-slate-400">
+              {formatBytes(file.size)}
+            </span>
+          </div>
+
+          <div className="card p-4">
+            <label className="block space-y-1">
+              <span className="field-label">
+                Number of colors: {count}
+              </span>
+
+              <input
+                type="range"
+                min={MIN_COLORS}
+                max={MAX_COLORS}
+                step="1"
+                value={count}
+                onChange={(e) => {
+                  setCount(Number(e.target.value))
+                  setCopied(null)
+                  reset()
+                }}
+                className="w-full accent-brand-600"
+              />
+            </label>
+
+            <p className="mt-2 text-xs text-slate-400">
+              Choose between {MIN_COLORS} and {MAX_COLORS} dominant
+              colors.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={go}
+            disabled={running}
+          >
+            <Icon
+              name="image"
+              className="h-4 w-4"
+            />
+            {running
+              ? 'Extracting colors...'
+              : 'Extract palette'}
+          </button>
+        </>
+      )}
+
+      {running && progress && (
+        <Progress
+          value={progress.value}
+          message={progress.message}
+        />
+      )}
+
+      {error && (
+        <Note
+          type="error"
+          title="Palette extraction failed"
+        >
+          {error}
+        </Note>
+      )}
+
+      {result && !running && (
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-sm font-semibold">
+              Dominant colors
+            </h2>
+            <p className="text-xs text-slate-400">
+              Click Copy to copy a HEX color value.
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {result.map((color) => (
+              <div
+                key={color.hex}
+                className="card overflow-hidden"
+              >
+                <div
+                  className="h-24 w-full"
+                  style={{
+                    backgroundColor: color.hex,
+                  }}
+                  aria-label={`Color ${color.hex}`}
+                />
+
+                <div className="space-y-3 p-4">
+                  <div>
+                    <p className="text-sm font-semibold">
+                      {color.hex}
+                    </p>
+                    <p className="text-xs text-slate-400">
+                      {color.rgb}
+                    </p>
+                  </div>
+
+                  <button
+                    type="button"
+                    className="btn-secondary w-full"
+                    onClick={() => copyColor(color)}
+                  >
+                    <Icon
+                      name="copy"
+                      className="h-4 w-4"
+                    />
+                    {copied === color.hex ? 'Copied!' : 'Copy HEX'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/operations/palette/meta.js
+++ b/src/operations/palette/meta.js
@@ -1,0 +1,8 @@
+export default {
+  id: 'palette',
+  name: 'Color Palette Extractor',
+  description: 'Extract dominant colors from an image as copyable HEX and RGB values.',
+  category: 'image',
+  icon: 'image',
+  order: 43,
+}


### PR DESCRIPTION
Closes #153

**What changed**
- Added a new Color Palette Extractor operation using the DoxDock plugin architecture.
- Extracts dominant colors from an uploaded image entirely in the browser.
- Supports an adjustable palette size from 3 to 12 colors.
- Displays HEX and RGB values for each detected color.
- Added one-click Copy HEX functionality for each color.
- Handles transparent images by ignoring mostly transparent pixels.
- Uses sampling and color bucketing to keep processing efficient for large images.
- Runs fully offline with no network calls or external assets.

**Acceptance criteria**
- [x] An image yields N dominant colors with copyable HEX values.
- [x] The number of colors is adjustable.
- [x] Runs fully offline.

**Proof**
- Tested with a normal photograph.
- Tested multiple palette sizes.
- Verified HEX values can be copied.
- Tested a single-color image.
- Tested while offline successfully.
- `npm run build` passes successfully.