### PR TITLE
feat: add image collage

### DIFF
--- a/src/operations/collage/helpers.js
+++ b/src/operations/collage/helpers.js
@@ -1,0 +1,293 @@
+import { decode, dimsOf, canvasToBlob } from '../../lib/imageCanvas.js'
+
+const MAX_IMAGES = 20
+const MAX_SPACING = 100
+const MAX_TILE_SIZE = 1600
+const MAX_OUTPUT_SIZE = 4096
+const JPEG_QUALITY = 0.9
+
+function validateColor(color) {
+  return /^#[0-9a-f]{6}$/i.test(color || '') ? color : '#ffffff'
+}
+
+function getGridColumns(count) {
+  return Math.max(1, Math.ceil(Math.sqrt(count)))
+}
+
+function getGridRows(count, columns) {
+  return Math.ceil(count / columns)
+}
+
+function fitDimensions(width, height, maxSize) {
+  const longestSide = Math.max(width, height)
+  const scale = longestSide > maxSize ? maxSize / longestSide : 1
+
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  }
+}
+
+function buildGridLayout(images, spacing) {
+  const columns = getGridColumns(images.length)
+  const rows = getGridRows(images.length, columns)
+
+  const rowHeights = Array(rows).fill(0)
+  const columnWidths = Array(columns).fill(0)
+
+  for (let i = 0; i < images.length; i += 1) {
+    const row = Math.floor(i / columns)
+    const column = i % columns
+
+    columnWidths[column] = Math.max(
+      columnWidths[column],
+      images[i].width,
+    )
+
+    rowHeights[row] = Math.max(
+      rowHeights[row],
+      images[i].height,
+    )
+  }
+
+  const width =
+    columnWidths.reduce((sum, value) => sum + value, 0) +
+    spacing * Math.max(0, columns - 1)
+
+  const height =
+    rowHeights.reduce((sum, value) => sum + value, 0) +
+    spacing * Math.max(0, rows - 1)
+
+  const positions = []
+
+  let currentY = 0
+
+  for (let row = 0; row < rows; row += 1) {
+    let currentX = 0
+
+    for (let column = 0; column < columns; column += 1) {
+      const index = row * columns + column
+
+      if (index >= images.length) break
+
+      const image = images[index]
+      const cellWidth = columnWidths[column]
+      const cellHeight = rowHeights[row]
+
+      positions.push({
+        x: currentX + (cellWidth - image.width) / 2,
+        y: currentY + (cellHeight - image.height) / 2,
+        width: image.width,
+        height: image.height,
+      })
+
+      currentX += cellWidth + spacing
+    }
+
+    currentY += rowHeights[row] + spacing
+  }
+
+  return { width, height, positions }
+}
+
+function buildHorizontalLayout(images, spacing) {
+  const width =
+    images.reduce((sum, image) => sum + image.width, 0) +
+    spacing * Math.max(0, images.length - 1)
+
+  const height = images.reduce(
+    (max, image) => Math.max(max, image.height),
+    0,
+  )
+
+  const positions = []
+  let x = 0
+
+  for (const image of images) {
+    positions.push({
+      x,
+      y: (height - image.height) / 2,
+      width: image.width,
+      height: image.height,
+    })
+
+    x += image.width + spacing
+  }
+
+  return { width, height, positions }
+}
+
+function buildVerticalLayout(images, spacing) {
+  const width = images.reduce(
+    (max, image) => Math.max(max, image.width),
+    0,
+  )
+
+  const height =
+    images.reduce((sum, image) => sum + image.height, 0) +
+    spacing * Math.max(0, images.length - 1)
+
+  const positions = []
+  let y = 0
+
+  for (const image of images) {
+    positions.push({
+      x: (width - image.width) / 2,
+      y,
+      width: image.width,
+      height: image.height,
+    })
+
+    y += image.height + spacing
+  }
+
+  return { width, height, positions }
+}
+
+function getLayout(images, layout, spacing) {
+  if (layout === 'horizontal') {
+    return buildHorizontalLayout(images, spacing)
+  }
+
+  if (layout === 'vertical') {
+    return buildVerticalLayout(images, spacing)
+  }
+
+  return buildGridLayout(images, spacing)
+}
+
+/**
+ * Combine multiple images into a single collage.
+ *
+ * @param {File[]} files
+ * @param {{layout?:'grid'|'horizontal'|'vertical', spacing?:number, background?:string}} opts
+ * @param {(value:number, message:string)=>void} onProgress
+ */
+export async function createCollage(files, opts, onProgress) {
+  if (!Array.isArray(files) || files.length < 2) {
+    throw new Error('Add at least two images to create a collage.')
+  }
+
+  if (files.length > MAX_IMAGES) {
+    throw new Error(`You can combine up to ${MAX_IMAGES} images at once.`)
+  }
+
+  const layout = ['grid', 'horizontal', 'vertical'].includes(opts?.layout)
+    ? opts.layout
+    : 'grid'
+
+  const spacingValue = Number(opts?.spacing)
+  const spacing = Number.isFinite(spacingValue)
+    ? Math.max(0, Math.min(MAX_SPACING, Math.round(spacingValue)))
+    : 12
+
+  const background = validateColor(opts?.background)
+
+  const bitmaps = []
+  const images = []
+
+  try {
+    for (let i = 0; i < files.length; i += 1) {
+      onProgress?.(
+        (i / files.length) * 0.45,
+        `Loading image ${i + 1} of ${files.length}...`,
+      )
+
+      const bitmap = await decode(files[i])
+      bitmaps.push(bitmap)
+
+      const { width, height } = dimsOf(bitmap)
+
+      if (!width || !height) {
+        throw new Error(
+          `Could not determine the dimensions of ${files[i].name}.`,
+        )
+      }
+
+      images.push(fitDimensions(width, height, MAX_TILE_SIZE))
+    }
+
+    onProgress?.(0.5, 'Calculating collage layout...')
+
+    const layoutResult = getLayout(images, layout, spacing)
+
+    if (!layoutResult.width || !layoutResult.height) {
+      throw new Error('Could not create the collage dimensions.')
+    }
+
+    const longestSide = Math.max(
+      layoutResult.width,
+      layoutResult.height,
+    )
+
+    const outputScale =
+      longestSide > MAX_OUTPUT_SIZE
+        ? MAX_OUTPUT_SIZE / longestSide
+        : 1
+
+    const canvas = document.createElement('canvas')
+
+    canvas.width = Math.max(
+      1,
+      Math.round(layoutResult.width * outputScale),
+    )
+
+    canvas.height = Math.max(
+      1,
+      Math.round(layoutResult.height * outputScale),
+    )
+
+    const ctx = canvas.getContext('2d')
+
+    if (!ctx) {
+      throw new Error('Could not prepare the collage canvas.')
+    }
+
+    ctx.fillStyle = background
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+    ctx.imageSmoothingEnabled = true
+    ctx.imageSmoothingQuality = 'high'
+
+    for (let i = 0; i < bitmaps.length; i += 1) {
+      onProgress?.(
+        0.5 + (i / bitmaps.length) * 0.4,
+        `Combining image ${i + 1} of ${bitmaps.length}...`,
+      )
+
+      const position = layoutResult.positions[i]
+      const bitmap = bitmaps[i]
+
+      ctx.drawImage(
+        bitmap,
+        Math.round(position.x * outputScale),
+        Math.round(position.y * outputScale),
+        Math.round(position.width * outputScale),
+        Math.round(position.height * outputScale),
+      )
+    }
+
+    onProgress?.(0.95, 'Encoding collage...')
+
+    const blob = await canvasToBlob(
+      canvas,
+      'jpeg',
+      JPEG_QUALITY,
+    )
+
+    onProgress?.(1, 'Done')
+
+    return {
+      blob,
+      filename: 'collage.jpg',
+      width: canvas.width,
+      height: canvas.height,
+      before: files.reduce((sum, file) => sum + file.size, 0),
+      after: blob.size,
+    }
+  } finally {
+    for (const bitmap of bitmaps) {
+      bitmap.close?.()
+    }
+  }
+}

--- a/src/operations/collage/index.jsx
+++ b/src/operations/collage/index.jsx
@@ -1,0 +1,244 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import ImageResult from '../../components/ImageResult.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes } from '../../lib/format.js'
+import { IMAGE_FORMATS_HINT } from '../../lib/imageCanvas.js'
+import { createCollage } from './helpers.js'
+
+const LAYOUTS = [
+  { value: 'grid', label: 'Grid' },
+  { value: 'horizontal', label: 'Horizontal' },
+  { value: 'vertical', label: 'Vertical' },
+]
+
+const MAX_SPACING = 100
+
+export default function Collage() {
+  const [files, setFiles] = useState([])
+  const [layout, setLayout] = useState('grid')
+  const [spacing, setSpacing] = useState(12)
+  const [background, setBackground] = useState('#ffffff')
+
+  const { running, progress, error, result, run, reset } = useJob()
+
+    const pick = (chosen) => {
+    setFiles((current) => {
+      const existing = new Set(
+        current.map(
+          (file) => `${file.name}-${file.size}-${file.lastModified}`,
+        ),
+      )
+
+      const additions = chosen.filter(
+        (file) =>
+          !existing.has(
+            `${file.name}-${file.size}-${file.lastModified}`,
+          ),
+      )
+
+      return [...current, ...additions]
+    })
+
+    reset()
+  }
+
+  const removeFile = (index) => {
+    setFiles((current) => current.filter((_, i) => i !== index))
+    reset()
+  }
+
+  const go = () => {
+    if (files.length < 2) return
+
+    run((onProgress) =>
+      createCollage(
+        files,
+        {
+          layout,
+          spacing: Number(spacing),
+          background,
+        },
+        onProgress,
+      ),
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        files={files}
+        accept="image/*"
+        multiple
+        label="Drop multiple images here or click to browse"
+        hint={IMAGE_FORMATS_HINT}
+        icon="image"
+      />
+
+      {files.length > 0 && (
+        <>
+          <div className="card p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-sm font-semibold">
+                  Selected images
+                </h2>
+                <p className="text-xs text-slate-400">
+                  {files.length} image{files.length === 1 ? '' : 's'} selected
+                </p>
+              </div>
+
+              <span className="text-xs text-slate-400">
+                {formatBytes(files.reduce((sum, file) => sum + file.size, 0))}
+              </span>
+            </div>
+
+            <div className="space-y-2">
+              {files.map((file, index) => (
+                <div
+                  key={`${file.name}-${file.size}-${index}`}
+                  className="flex items-center gap-3 rounded-lg border border-slate-200 p-3 dark:border-slate-700"
+                >
+                  <Icon
+                    name="image"
+                    className="h-5 w-5 shrink-0 text-brand-600"
+                  />
+
+                  <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                    {file.name}
+                  </span>
+
+                  <span className="text-xs text-slate-400">
+                    {formatBytes(file.size)}
+                  </span>
+
+                  <button
+                    type="button"
+                    className="btn-secondary px-3 py-1.5 text-xs"
+                    onClick={() => removeFile(index)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="card space-y-5 p-4">
+            <div>
+              <span className="field-label">Layout</span>
+
+              <div className="mt-2 grid gap-2 sm:grid-cols-3">
+                {LAYOUTS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={
+                      layout === option.value
+                        ? 'btn-primary'
+                        : 'btn-secondary'
+                    }
+                    onClick={() => {
+                      setLayout(option.value)
+                      reset()
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <label className="block space-y-1">
+              <span className="field-label">
+                Spacing: {spacing}px
+              </span>
+
+              <input
+                type="range"
+                min="0"
+                max={MAX_SPACING}
+                step="1"
+                value={spacing}
+                onChange={(e) => {
+                  setSpacing(Number(e.target.value))
+                  reset()
+                }}
+                className="w-full accent-brand-600"
+              />
+            </label>
+
+            <label className="flex items-center justify-between gap-4">
+              <div>
+                <span className="field-label">Background color</span>
+                <p className="mt-1 text-xs text-slate-400">
+                  Used for the space around the images.
+                </p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  value={background}
+                  onChange={(e) => {
+                    setBackground(e.target.value)
+                    reset()
+                  }}
+                  className="h-10 w-14 cursor-pointer rounded border border-slate-300 bg-white p-1 dark:border-slate-700 dark:bg-slate-900"
+                  aria-label="Choose background color"
+                />
+
+                <span className="font-mono text-xs uppercase text-slate-500">
+                  {background}
+                </span>
+              </div>
+            </label>
+          </div>
+
+          {files.length < 2 && (
+            <Note type="info">
+              Add at least two images to create a collage.
+            </Note>
+          )}
+
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={go}
+            disabled={running || files.length < 2}
+          >
+            <Icon
+              name="image"
+              className="h-4 w-4"
+            />
+            {running ? 'Creating collage...' : 'Create collage'}
+          </button>
+        </>
+      )}
+
+      {running && progress && (
+        <Progress
+          value={progress.value}
+          message={progress.message}
+        />
+      )}
+
+      {error && (
+        <Note
+          type="error"
+          title="Collage creation failed"
+        >
+          {error}
+        </Note>
+      )}
+
+      {result && !running && (
+        <ImageResult result={result} />
+      )}
+    </div>
+  )
+}

--- a/src/operations/collage/meta.js
+++ b/src/operations/collage/meta.js
@@ -1,0 +1,8 @@
+export default {
+  id: 'collage',
+  name: 'Collage / Combine Images',
+  description: 'Combine multiple images into one collage with grid, horizontal, or vertical layouts.',
+  category: 'image',
+  icon: 'image',
+  order: 44,
+}


### PR DESCRIPTION
Closes #150

**What changed**

- Added a new Collage / Combine Images operation using the DoxDock plugin architecture.
- Supports combining multiple images into a single downloadable collage.
- Added Grid, Horizontal, and Vertical layouts.
- Added adjustable spacing from 0–100 px.
- Added a customizable background color.
- Preserves image aspect ratios without stretching.
- Added safeguards for large images and large output dimensions.
- Uses JPEG output to keep photographic collages reasonably sized.
- Runs fully offline with no network calls or external assets.

**Acceptance criteria**

- [x] Multiple images combine into one downloadable image in the chosen layout.
- [x] Spacing and background are adjustable.
- [x] Runs fully offline.

**Testing**

- Tested multiple-image selection.
- Tested Grid layout.
- Tested Horizontal layout.
- Tested Vertical layout.
- Tested adjustable spacing.
- Tested custom background color.
- Verified large source images produce a reasonably sized output.
- Verified `npm run build` passes successfully.
- Verified processing works offline.