### PR TITLE
feat: add ★ to GitHub footer link — Closes #8

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -314,7 +314,7 @@ export default function App() {
                 className="inline-flex items-center gap-1 font-medium text-slate-500 hover:text-brand-600 dark:text-slate-300 dark:hover:text-brand-300"
               >
                 <Icon name="github" className="h-3.5 w-3.5" />
-                Star us on GitHub
+                Star us on GitHub ★
               </a>
             </p>
           </footer>


### PR DESCRIPTION
## What
Adds the ★ character to the 'Star us on GitHub' footer link per the acceptance criteria in #8.

## Changes
- `src/App.jsx`: Appended ★ to the GitHub link text in the footer.

## Checklist
- [x] Runs fully offline
- [x] No new dependencies
- [x] Passes lint and build