### PR TITLE
feat: add CSV to PDF table converter — Closes #172

### DIFF
--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -101,6 +101,8 @@ const P = {
   home: '<path d="m3 10 9-7 9 7v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 21V12h6v9"/>',
   panelLeft: '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M9 4v16"/>',
   sparkles: '<path d="M12 3v4M12 17v4M3 12h4M17 12h4M6 6l2 2M16 16l2 2M18 6l-2 2M8 16l-2 2"/>',
+  table:
+    '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18M9 3v18M15 3v18"/>',
 }
 
 export const iconNames = Object.keys(P)

--- a/src/operations/csv-to-pdf/helpers.js
+++ b/src/operations/csv-to-pdf/helpers.js
@@ -86,9 +86,12 @@ export async function csvToPdf(file, opts, onProgress) {
   const lineHeight = fontSize * 1.4
   const headerH = showHeader ? lineHeight + 4 : 0
   const maxRows = Math.min(rows.length, 2000) // safety cap
+  const truncated = rows.length > 2000
+
+  if (truncated) onProgress?.(0.2, `Showing the first 2000 of ${rows.length} rows`)
 
   // Calculate column widths based on max content width.
-  const numCols = Math.max(...rows.map((r) => r.length))
+  const numCols = rows.reduce((max, r) => Math.max(max, r.length), 0)
   const colWidths = []
   for (let c = 0; c < numCols; c++) {
     let maxW = 40
@@ -116,7 +119,7 @@ export async function csvToPdf(file, opts, onProgress) {
   const drawHeader = (pg) => {
     if (!showHeader) return
     let x = margin
-    const hy = pg.getSize().y - margin - fontSize
+    const hy = pg.getHeight() - margin - fontSize
     for (let c = 0; c < numCols; c++) {
       const cell = (rows[0]?.[c] || '').substring(0, 60)
       pg.drawText(cell, { x, y: hy, size: fontSize, font: boldFont, color: rgb(0.15, 0.15, 0.15) })
@@ -137,7 +140,7 @@ export async function csvToPdf(file, opts, onProgress) {
       }
     }
 
-    const py = page.getSize().y - margin - headerH - (y * lineHeight) - fontSize
+    const py = page.getHeight() - margin - headerH - (y * lineHeight) - fontSize
     let x = margin
     for (let c = 0; c < numCols; c++) {
       const cell = (rows[r]?.[c] || '').substring(0, 60)

--- a/src/operations/csv-to-pdf/helpers.js
+++ b/src/operations/csv-to-pdf/helpers.js
@@ -1,0 +1,162 @@
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib'
+
+/** Detect the delimiter used in a CSV string. */
+function detectDelimiter(text) {
+  const firstLine = text.split('\n')[0] || ''
+  if (firstLine.split('\t').length > 1) return '\t'
+  if (firstLine.split(';').length > firstLine.split(',').length) return ';'
+  return ','
+}
+
+/** Parse a CSV string into a 2D array of strings, handling quoted fields. */
+function parseCSV(text, delimiter) {
+  const rows = []
+  let current = []
+  let field = ''
+  let inQuotes = false
+  const lines = text.replace(/\r\n?/g, '\n').split('\n')
+
+  for (const line of lines) {
+    // Empty trailing line
+    if (line === '' && rows.length > 0) continue
+
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i]
+      if (inQuotes) {
+        if (ch === '"') {
+          if (i + 1 < line.length && line[i + 1] === '"') {
+            field += '"'
+            i++ // skip escaped quote
+          } else {
+            inQuotes = false
+          }
+        } else {
+          field += ch
+        }
+      } else {
+        if (ch === '"') {
+          inQuotes = true
+        } else if (ch === delimiter) {
+          current.push(field)
+          field = ''
+        } else {
+          field += ch
+        }
+      }
+    }
+    current.push(field)
+    field = ''
+    rows.push(current)
+    current = []
+  }
+  return rows
+}
+
+/**
+ * Convert CSV text to a PDF table.
+ *
+ * @param {File} file
+ * @param {{fontSize:number, showHeader:boolean, orientation:'landscape'|'portrait'}} opts
+ * @param {(v:number,m:string)=>void} onProgress
+ * @returns {Promise<Blob>}
+ */
+export async function csvToPdf(file, opts, onProgress) {
+  const { fontSize = 8, showHeader = true, orientation = 'landscape' } = opts || {}
+
+  onProgress?.(0.1, 'Reading CSV…')
+  const text = await file.text()
+  if (!text.trim()) throw new Error('The CSV file is empty.')
+
+  const delimiter = detectDelimiter(text)
+  const rows = parseCSV(text, delimiter)
+  if (rows.length === 0) throw new Error('No data rows found in the CSV.')
+
+  onProgress?.(0.3, 'Building PDF…')
+
+  const doc = await PDFDocument.create()
+  const font = await doc.embedFont(StandardFonts.Helvetica)
+  const boldFont = await doc.embedFont(StandardFonts.HelveticaBold)
+
+  const isLandscape = orientation === 'landscape'
+  const pageW = isLandscape ? 842 : 595
+  const pageH = isLandscape ? 595 : 842
+  const margin = 36
+  const usableW = pageW - margin * 2
+  const usableH = pageH - margin * 2
+  const lineHeight = fontSize * 1.4
+  const headerH = showHeader ? lineHeight + 4 : 0
+  const maxRows = Math.min(rows.length, 2000) // safety cap
+
+  // Calculate column widths based on max content width.
+  const numCols = Math.max(...rows.map((r) => r.length))
+  const colWidths = []
+  for (let c = 0; c < numCols; c++) {
+    let maxW = 40
+    for (let r = 0; r < maxRows; r++) {
+      const cell = (rows[r]?.[c] || '').substring(0, 60)
+      const w = font.widthOfTextAtSize(cell, fontSize)
+      if (w > maxW) maxW = w
+    }
+    colWidths.push(maxW + 12) // padding
+  }
+
+  // Scale columns to fit usable width.
+  const totalW = colWidths.reduce((a, b) => a + b, 0)
+  if (totalW > usableW) {
+    const scale = usableW / totalW
+    for (let c = 0; c < colWidths.length; c++) colWidths[c] *= scale
+  }
+
+  // Paginate rows.
+  const rowsPerPage = Math.max(1, Math.floor((usableH - headerH) / lineHeight))
+  let page = null
+  let y = 0
+  let pageNum = 0
+
+  const drawHeader = (pg) => {
+    if (!showHeader) return
+    let x = margin
+    const hy = pg.getSize().y - margin - fontSize
+    for (let c = 0; c < numCols; c++) {
+      const cell = (rows[0]?.[c] || '').substring(0, 60)
+      pg.drawText(cell, { x, y: hy, size: fontSize, font: boldFont, color: rgb(0.15, 0.15, 0.15) })
+      x += colWidths[c] || 0
+    }
+  }
+
+  const startRow = showHeader ? 1 : 0
+
+  for (let r = startRow; r < maxRows; r++) {
+    if (y === 0 || y >= rowsPerPage) {
+      page = doc.addPage([pageW, pageH])
+      pageNum++
+      y = 0
+      if (showHeader && r === startRow) {
+        drawHeader(page)
+        y = 1 // skip header row slot
+      }
+    }
+
+    const py = page.getSize().y - margin - headerH - (y * lineHeight) - fontSize
+    let x = margin
+    for (let c = 0; c < numCols; c++) {
+      const cell = (rows[r]?.[c] || '').substring(0, 60)
+      pg_drawText(page, cell, { x, y: py, size: fontSize, font, color: rgb(0.2, 0.2, 0.2) })
+      x += colWidths[c] || 0
+    }
+    y++
+
+    if (r % 50 === 0) onProgress?.(0.3 + (r / maxRows) * 0.6, `Rendering row ${r}…`)
+  }
+
+  onProgress?.(0.95, 'Saving…')
+  const bytes = await doc.save()
+  onProgress?.(1, 'Done')
+  return new Blob([bytes], { type: 'application/pdf' })
+}
+
+/** pdf-lib drawText helper — silent no-op for empty text. */
+function pg_drawText(page, text, opts) {
+  if (!text) return
+  try { page.drawText(text, opts) } catch { /* skip unrenderable chars */ }
+}

--- a/src/operations/csv-to-pdf/index.jsx
+++ b/src/operations/csv-to-pdf/index.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import DownloadButton from '../../components/DownloadButton.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes, baseName } from '../../lib/format.js'
+import { csvToPdf } from './helpers.js'
+
+export default function CsvToPdf() {
+  const [file, setFile] = useState(null)
+  const [fontSize, setFontSize] = useState(8)
+  const [showHeader, setShowHeader] = useState(true)
+  const [orientation, setOrientation] = useState('landscape')
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const pick = (files) => {
+    setFile(files[0])
+    reset()
+  }
+  const go = () =>
+    run((p) =>
+      csvToPdf(file, { fontSize: Number(fontSize), showHeader, orientation }, p).then(
+        (blob) => ({ blob, filename: `${baseName(file.name)}.pdf` }),
+      ),
+    )
+
+  return (
+    <div className="space-y-6">
+      <Dropzone onFiles={pick} accept=".csv,.tsv,.txt,text/csv" multiple={false} label="Drop a CSV file here or click to browse" hint="Comma, semicolon, or tab delimited" icon="table" />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="table" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+            <span className="text-xs text-slate-400">{formatBytes(file.size)}</span>
+          </div>
+
+          <div className="card space-y-4 p-4">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <label className="space-y-1">
+                <span className="field-label">Orientation</span>
+                <select className="field-input" value={orientation} onChange={(e) => setOrientation(e.target.value)}>
+                  <option value="landscape">Landscape</option>
+                  <option value="portrait">Portrait</option>
+                </select>
+              </label>
+              <label className="space-y-1">
+                <span className="field-label">Font size: {fontSize}pt</span>
+                <input type="range" min="6" max="14" value={fontSize} onChange={(e) => setFontSize(e.target.value)} className="w-full accent-brand-600" />
+              </label>
+              <label className="flex items-center gap-2 pt-6">
+                <input type="checkbox" checked={showHeader} onChange={(e) => setShowHeader(e.target.checked)} className="accent-brand-600" />
+                <span className="text-sm text-slate-700 dark:text-slate-300">Bold header row</span>
+              </label>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button type="button" className="btn-primary" onClick={go} disabled={running}>
+              <Icon name="table" className="h-4 w-4" />
+              Convert to PDF
+            </button>
+            {result && <DownloadButton result={result} />}
+          </div>
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && <Note type="error" title="Conversion failed">{error}</Note>}
+    </div>
+  )
+}

--- a/src/operations/csv-to-pdf/meta.js
+++ b/src/operations/csv-to-pdf/meta.js
@@ -1,0 +1,10 @@
+export default {
+  id: 'csv-to-pdf',
+  name: 'CSV to PDF',
+  description: 'Render a CSV spreadsheet as a formatted PDF table.',
+  category: 'pdf',
+  icon: 'table',
+  order: 30,
+  notes:
+    'Parses CSV data and renders it as a clean, paginated table in a PDF. Supports comma, semicolon, and tab delimiters. Text cells are truncated to keep the layout tidy. Runs entirely in your browser.',
+}


### PR DESCRIPTION
## What
Renders a CSV file as a formatted, paginated PDF table, as described in #172.

## Features
- Parses CSV with auto-detected delimiters (comma, semicolon, tab)
- Handles quoted fields correctly
- Landscape and portrait page orientations
- Configurable font size (6–14pt)
- Optional bold header row
- Paginated output for large datasets
- Client-side only — no network requests

## Implementation
- `src/operations/csv-to-pdf/{meta.js,index.jsx,helpers.js}`
- Added `table` icon to `src/components/Icon.jsx`
- Uses pdf-lib for PDF generation with Helvetica fonts

## Checklist
- [x] CSV renders as a clean PDF table
- [x] Pagination for large files
- [x] Runs fully offline