### PR TITLE
feat: add crop PDF tool — Closes #145

### DIFF
--- a/src/operations/crop-pdf/helpers.js
+++ b/src/operations/crop-pdf/helpers.js
@@ -1,0 +1,92 @@
+import { PDFDocument } from 'pdf-lib'
+import { loadPdf } from '../../lib/pdfjs.js'
+
+/**
+ * Load a PDF for rendering with pdf.js.
+ */
+export function openForCrop(bytes) {
+  return loadPdf(bytes.slice(0))
+}
+
+/**
+ * Render a single page to a canvas. Returns page dimensions and scale info.
+ */
+export async function renderPage(pdfjsDoc, pageNumber, canvas, cssWidth) {
+  const page = await pdfjsDoc.getPage(pageNumber)
+  const base = page.getViewport({ scale: 1 })
+  const widthPt = base.width
+  const heightPt = base.height
+  const scale = cssWidth / widthPt
+  const dpr = Math.min(window.devicePixelRatio || 1, 2)
+  const viewport = page.getViewport({ scale: scale * dpr })
+  canvas.width = Math.round(viewport.width)
+  canvas.height = Math.round(viewport.height)
+  canvas.style.width = `${cssWidth}px`
+  canvas.style.height = `${heightPt * scale}px`
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  if (canvas.__task) {
+    try { canvas.__task.cancel() } catch { /* ignore */ }
+  }
+  const task = page.render({ canvasContext: ctx, viewport })
+  canvas.__task = task
+  task.promise.catch(() => {}).finally(() => {
+    if (canvas.__task === task) canvas.__task = null
+  })
+  return { widthPt, heightPt, scale: scale * dpr }
+}
+
+/**
+ * Apply a crop box to PDF pages.
+ *
+ * @param {File} file
+ * @param {{x:number, y:number, w:number, h:number, pageWidth:number, pageHeight:number,
+ *          pageIndex:number, applyAll:boolean}} cropInfo
+ * @param {(v:number,m:string)=>void} onProgress
+ * @returns {Promise<Blob>}
+ */
+export async function cropPdf(file, cropInfo, onProgress) {
+  const { x, y, w, h, pageWidth, pageHeight, pageIndex, applyAll } = cropInfo
+
+  onProgress?.(0.1, 'Loading PDF…')
+  const bytes = await file.arrayBuffer()
+  const doc = await PDFDocument.load(bytes)
+  const pages = doc.getPages()
+
+  // Convert canvas coordinates (top-left origin, CSS pixels) to PDF points (bottom-left origin).
+  // The crop rectangle in canvas coords: (x, y) is top-left, w x h is size.
+  // PDF CropBox: (x1, y1) is bottom-left corner, (x2, y2) is top-right corner.
+  const cropX = x
+  const cropYTop = y
+  const cropX2 = x + w
+  const cropY2Top = y + h
+
+  // Convert from top-left origin to bottom-left origin (PDF coords).
+  const pdfX1 = (cropX / (cropInfo.canvasWidth || pageWidth)) * pageWidth
+  const pdfY1 = pageHeight - (cropY2Top / (cropInfo.canvasHeight || pageHeight)) * pageHeight
+  const pdfX2 = (cropX2 / (cropInfo.canvasWidth || pageWidth)) * pageWidth
+  const pdfY2 = pageHeight - (cropYTop / (cropInfo.canvasHeight || pageHeight)) * pageHeight
+
+  const clampedX = Math.max(0, Math.min(pdfX1, pageWidth))
+  const clampedY = Math.max(0, Math.min(pdfY1, pageHeight))
+  const clampedX2 = Math.max(0, Math.min(pdfX2, pageWidth))
+  const clampedY2 = Math.max(0, Math.min(pdfY2, pageHeight))
+
+  if (clampedX2 - clampedX < 10 || clampedY2 - clampedY < 10) {
+    throw new Error('The crop area is too small. Draw a larger rectangle.')
+  }
+
+  const targetPages = applyAll ? pages : [pages[pageIndex]]
+
+  for (let i = 0; i < targetPages.length; i++) {
+    onProgress?.(0.3 + (0.6 * i) / targetPages.length, `Cropping page ${i + 1}…`)
+    const page = targetPages[i]
+    page.setCropBox(clampedX, clampedY, clampedX2 - clampedX, clampedY2 - clampedY)
+  }
+
+  onProgress?.(0.95, 'Saving…')
+  const out = await doc.save()
+  onProgress?.(1, 'Done')
+  return new Blob([out], { type: 'application/pdf' })
+}

--- a/src/operations/crop-pdf/index.jsx
+++ b/src/operations/crop-pdf/index.jsx
@@ -1,0 +1,172 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import DownloadButton from '../../components/DownloadButton.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes, baseName } from '../../lib/format.js'
+import { openForCrop, renderPage, cropPdf } from './helpers.js'
+
+export default function CropPdf() {
+  const [file, setFile] = useState(null)
+  const [pdfDoc, setPdfDoc] = useState(null)
+  const [pageIndex, setPageIndex] = useState(0)
+  const [pageCount, setPageCount] = useState(0)
+  const [pageDims, setPageDims] = useState(null)
+  const [applyAll, setApplyAll] = useState(false)
+  const [cropRect, setCropRect] = useState(null)
+  const [drawing, setDrawing] = useState(false)
+  const [drawStart, setDrawStart] = useState(null)
+  const canvasRef = useRef(null)
+  const overlayRef = useRef(null)
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const pick = useCallback(async (files) => {
+    const f = files[0]
+    setFile(f)
+    setPdfDoc(null)
+    setCropRect(null)
+    setPageIndex(0)
+    reset()
+    try {
+      const buf = await f.arrayBuffer()
+      const doc = await openForCrop(buf)
+      setPdfDoc(doc)
+      setPageCount(doc.numPages)
+    } catch (err) {
+      setPdfDoc(null)
+    }
+  }, [reset])
+
+  useEffect(() => {
+    if (!pdfDoc || !canvasRef.current) return
+    const w = canvasRef.current.parentElement?.clientWidth || 600
+    renderPage(pdfDoc, pageIndex + 1, canvasRef.current, Math.min(w, 700)).then((d) => {
+      setPageDims(d)
+      setCropRect(null)
+    })
+  }, [pdfDoc, pageIndex])
+
+  const toCanvasCoords = (e) => {
+    if (!overlayRef.current) return { cx: 0, cy: 0 }
+    const rect = overlayRef.current.getBoundingClientRect()
+    return { cx: e.clientX - rect.left, cy: e.clientY - rect.top }
+  }
+
+  const onMouseDown = (e) => {
+    const { cx, cy } = toCanvasCoords(e)
+    setDrawStart({ cx, cy })
+    setCropRect(null)
+    setDrawing(true)
+  }
+
+  const onMouseMove = (e) => {
+    if (!drawing || !drawStart) return
+    const { cx, cy } = toCanvasCoords(e)
+    const x = Math.min(drawStart.cx, cx)
+    const y = Math.min(drawStart.cy, cy)
+    const w = Math.abs(cx - drawStart.cx)
+    const h = Math.abs(cy - drawStart.cy)
+    setCropRect({ x, y, w, h })
+  }
+
+  const onMouseUp = () => {
+    setDrawing(false)
+    setDrawStart(null)
+  }
+
+  const go = () => {
+    if (!cropRect || !pageDims || !file) return
+    run((p) =>
+      cropPdf(file, {
+        x: cropRect.x,
+        y: cropRect.y,
+        w: cropRect.w,
+        h: cropRect.h,
+        pageWidth: pageDims.widthPt,
+        pageHeight: pageDims.heightPt,
+        canvasWidth: canvasRef.current?.width || 1,
+        canvasHeight: canvasRef.current?.height || 1,
+        pageIndex,
+        applyAll,
+      }, p).then((blob) => ({ blob, filename: `${baseName(file.name)}-cropped.pdf` })),
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <Dropzone onFiles={pick} accept="application/pdf,.pdf" multiple={false} label="Drop a PDF here or click to browse" icon="scissors" />
+
+      {file && pdfDoc && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="fileText" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+            <span className="text-xs text-slate-400">{formatBytes(file.size)} · {pageCount} pages</span>
+          </div>
+
+          {pageCount > 1 && (
+            <div className="card p-4">
+              <label className="space-y-1">
+                <span className="field-label">Page: {pageIndex + 1} / {pageCount}</span>
+                <input type="range" min="0" max={pageCount - 1} value={pageIndex} onChange={(e) => setPageIndex(Number(e.target.value))} className="w-full accent-brand-600" />
+              </label>
+            </div>
+          )}
+
+          <div className="card p-4">
+            <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+              Draw a rectangle on the page to define the crop area. The crop region will be visible; everything outside it is trimmed.
+            </p>
+            <div className="relative inline-block border border-slate-200 dark:border-slate-700">
+              <canvas ref={canvasRef} />
+              <div
+                ref={overlayRef}
+                className="absolute inset-0 cursor-crosshair"
+                onMouseDown={onMouseDown}
+                onMouseMove={onMouseMove}
+                onMouseUp={onMouseUp}
+                onMouseLeave={onMouseUp}
+              >
+                {cropRect && (
+                  <div
+                    className="border-2 border-brand-500 bg-brand-500/10"
+                    style={{
+                      position: 'absolute',
+                      left: cropRect.x,
+                      top: cropRect.y,
+                      width: cropRect.w,
+                      height: cropRect.h,
+                      pointerEvents: 'none',
+                    }}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="card p-4 space-y-4">
+            <label className="flex items-center gap-2">
+              <input type="checkbox" checked={applyAll} onChange={(e) => setApplyAll(e.target.checked)} className="accent-brand-600" />
+              <span className="text-sm text-slate-700 dark:text-slate-300">
+                Apply crop to all {pageCount} pages
+              </span>
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button type="button" className="btn-primary" onClick={go} disabled={running || !cropRect}>
+              <Icon name="scissors" className="h-4 w-4" />
+              Crop PDF
+            </button>
+            {result && <DownloadButton result={result} />}
+          </div>
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && <Note type="error" title="Crop failed">{error}</Note>}
+    </div>
+  )
+}

--- a/src/operations/crop-pdf/index.jsx
+++ b/src/operations/crop-pdf/index.jsx
@@ -78,6 +78,7 @@ export default function CropPdf() {
 
   const go = () => {
     if (!cropRect || !pageDims || !file) return
+    const overlayRect = overlayRef.current?.getBoundingClientRect()
     run((p) =>
       cropPdf(file, {
         x: cropRect.x,
@@ -86,8 +87,8 @@ export default function CropPdf() {
         h: cropRect.h,
         pageWidth: pageDims.widthPt,
         pageHeight: pageDims.heightPt,
-        canvasWidth: canvasRef.current?.width || 1,
-        canvasHeight: canvasRef.current?.height || 1,
+        canvasWidth: overlayRect?.width || canvasRef.current?.getBoundingClientRect().width || 1,
+        canvasHeight: overlayRect?.height || canvasRef.current?.getBoundingClientRect().height || 1,
         pageIndex,
         applyAll,
       }, p).then((blob) => ({ blob, filename: `${baseName(file.name)}-cropped.pdf` })),

--- a/src/operations/crop-pdf/meta.js
+++ b/src/operations/crop-pdf/meta.js
@@ -1,0 +1,10 @@
+export default {
+  id: 'crop-pdf',
+  name: 'Crop PDF',
+  description: 'Trim margins or crop to a selected region on PDF pages.',
+  category: 'pdf',
+  icon: 'scissors',
+  order: 19,
+  notes:
+    'Draw a rectangle on the page preview to define the crop area. Apply to the current page or all pages. Uses the PDF CropBox specification — no pixels are thrown away, only the visible region changes.',
+}


### PR DESCRIPTION
## What
Adds a tool to crop PDF pages by drawing a rectangle on a rendered preview, as described in #145.

## Features
- Interactive crop box drawing on the page preview
- Page-by-page navigation with a slider
- Apply crop to current page or all pages
- Uses PDF CropBox specification (non-destructive)
- Page preview rendered via pdf.js, crop applied via pdf-lib

## Implementation
- `src/operations/crop-pdf/{meta.js,index.jsx,helpers.js}`
- Renders PDF pages with pdf.js for the preview
- Sets CropBox with pdf-lib for the output
- 100% client-side, no network requests

## Checklist
- [x] Exported PDF is cropped to the chosen box
- [x] Single-page and all-pages modes both work
- [x] Runs fully offline