### PR TITLE
feat: add star call to action in footer

### DIFF
--- a/e2e/footer.spec.mjs
+++ b/e2e/footer.spec.mjs
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test'
+
+test('footer links to the repository for starring', async ({ page }) => {
+  await page.goto('/')
+
+  const link = page.getByRole('link', { name: 'Star us on GitHub ★' })
+  await expect(link).toBeVisible()
+  await expect(link).toHaveAttribute('href', 'https://github.com/mithun-srinivas/DoxDock')
+  await expect(link).toHaveAttribute('target', '_blank')
+  await expect(link).toHaveAttribute('rel', /(^|\s)noopener(\s|$)/)
+  await expect(link).toHaveAttribute('rel', /(^|\s)noreferrer(\s|$)/)
+})

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -314,7 +314,7 @@ export default function App() {
                 className="inline-flex items-center gap-1 font-medium text-slate-500 hover:text-brand-600 dark:text-slate-300 dark:hover:text-brand-300"
               >
                 <Icon name="github" className="h-3.5 w-3.5" />
-                Star us on GitHub
+                Star us on GitHub ★
               </a>
             </p>
           </footer>


### PR DESCRIPTION
Closes #8

## What
- Completes the footer call to action as `Star us on GitHub ★`.
- Keeps the repository link opening safely in a new tab with `noopener noreferrer`.
- Adds focused Playwright coverage for visibility, destination, new-tab behavior, and safe `rel` attributes.

## Verification
- `npx playwright test --config=playwright.config.mjs e2e/footer.spec.mjs` — 1 passed.
- `npx playwright test --config=playwright.config.mjs e2e/network-isolation.spec.mjs -g "app loads"` — 1 passed.
- `npm run build` — passed.
- `npx prettier --check e2e/footer.spec.mjs` — passed.
- `git diff --check` — clean.
