### PR TITLE
feat: add PDF password removal

### DIFF
--- a/src/operations/unlock-pdf/helpers.js
+++ b/src/operations/unlock-pdf/helpers.js
@@ -1,0 +1,55 @@
+import { createQpdfRunner } from 'qpdf-run'
+
+async function createRunner() {
+  const workerUrl = new URL('qpdf-run/worker', import.meta.url).href
+  const qpdfJsUrl = new URL('qpdf-run/qpdf.js', import.meta.url).href
+  const wasmUrl = new URL('qpdf-run/qpdf.wasm', import.meta.url).href
+
+  return createQpdfRunner({
+    workerUrl,
+    qpdfJsUrl,
+    wasmUrl,
+    timeoutMs: 60000,
+  })
+}
+
+export async function unlockPdf(file, password, onProgress) {
+  if (!file || !/\.pdf$/i.test(file.name)) {
+    throw new Error('Please choose a PDF file.')
+  }
+
+  if (!password || !password.trim()) {
+    throw new Error('Please enter the PDF password.')
+  }
+
+  onProgress?.(0.1, 'Loading PDF decryption engine�')
+
+  const input = new Uint8Array(await file.arrayBuffer())
+  const qpdf = await createRunner()
+
+  try {
+    onProgress?.(0.25, 'Removing PDF password�')
+
+    const output = await qpdf.runOne({
+      input,
+      inputName: 'input.pdf',
+      outputName: 'unlocked.pdf',
+      args: [`--password=${password}`, '--decrypt', '--', 'input.pdf', 'unlocked.pdf'],
+    })
+
+    onProgress?.(0.95, 'Finalizing unlocked PDF�')
+
+    return new Blob([output], { type: 'application/pdf' })
+  } catch (error) {
+    if (error?.code === 'QPDF_EXEC_FAILED') {
+      throw new Error(
+        'Incorrect password or unsupported PDF encryption. Please check the password and try again.',
+        { cause: error },
+      )
+    }
+
+    throw error
+  } finally {
+    await qpdf.destroy()
+  }
+}

--- a/src/operations/unlock-pdf/index.jsx
+++ b/src/operations/unlock-pdf/index.jsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import DownloadButton from '../../components/DownloadButton.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes, baseName } from '../../lib/format.js'
+import { unlockPdf } from './helpers.js'
+
+export default function UnlockPdf() {
+  const [file, setFile] = useState(null)
+  const [password, setPassword] = useState('')
+  const { running, progress, error, result, run, reset } = useJob()
+
+  const pick = (files) => {
+    setFile(files[0] || null)
+    setPassword('')
+    reset()
+  }
+
+  const go = () => {
+    if (!password.trim()) return
+
+    run((onProgress) =>
+      unlockPdf(file, password, onProgress).then((blob) => ({
+        blob,
+        filename: `${baseName(file.name)}-unlocked.pdf`,
+      })),
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        accept="application/pdf,.pdf"
+        multiple={false}
+        label="Drop a protected PDF here or click to browse"
+        hint="The PDF stays in your browser and is never uploaded"
+        icon="unlock"
+      />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="fileText" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+            <span className="text-xs text-slate-400">{formatBytes(file.size)}</span>
+          </div>
+
+          <div className="card space-y-4 p-4">
+            <label className="block space-y-1">
+              <span className="field-label">PDF password</span>
+              <input
+                type="password"
+                className="field-input"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value)
+                  reset()
+                }}
+                autoComplete="off"
+                placeholder="Enter the existing PDF password"
+              />
+            </label>
+
+            <Note type="info" title="Known password required">
+              This tool only removes protection when you already know the PDF password. It cannot crack or
+              bypass a password.
+            </Note>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button type="button" className="btn-primary" onClick={go} disabled={running || !password.trim()}>
+              <Icon name="unlock" className="h-4 w-4" />
+              Unlock PDF
+            </button>
+
+            {result && !running && <DownloadButton result={result} />}
+          </div>
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+
+      {error && (
+        <Note type="error" title="Unlock failed">
+          {error}
+        </Note>
+      )}
+
+      {result && !running && (
+        <Note type="info" title="PDF unlocked">
+          The downloaded PDF no longer requires a password to open.
+        </Note>
+      )}
+    </div>
+  )
+}

--- a/src/operations/unlock-pdf/meta.js
+++ b/src/operations/unlock-pdf/meta.js
@@ -1,0 +1,10 @@
+export default {
+  id: 'unlock-pdf',
+  name: 'Unlock PDF',
+  description: 'Remove password protection from a PDF when you know the password.',
+  category: 'pdf',
+  icon: 'unlock',
+  order: 16,
+  notes:
+    'Decrypts a password-protected PDF using the password you provide. This tool does not crack or bypass passwords. Runs entirely in your browser using local qpdf WebAssembly.',
+}


### PR DESCRIPTION
### Which issue does this close?

Closes #84

### What changed

Added a new **Unlock PDF** operation at `src/operations/unlock-pdf/`.

The tool lets users select a password-protected PDF, enter the known password, and download an unprotected copy. It uses the same locally bundled `qpdf` WebAssembly engine introduced for Protect PDF and runs entirely in the browser.

The implementation follows DoxDock's plugin pattern and reuses the shared Dropzone, Progress, Note, DownloadButton, and useJob components.

### Acceptance criteria

* [x] Given the correct password, the output PDF opens without requiring a password.
* [x] A wrong password shows a clear error and does not produce an output.
* [x] Runs fully offline with no external network requests.

### Checklist

* [x] Runs fully offline: no network calls, no CDNs, no external assets.
* [x] Uses the same local qpdf WebAssembly engine as Protect PDF.
* [x] Follows the plugin pattern and reuses shared components.
* [x] `npm test` — 40/40 tests passed.
* [x] `npm run build` — passed.
* [x] ESLint — passed.

### Proof

Manual browser testing with a real password-protected PDF confirmed:

* Correct password → PDF successfully unlocked.
* Wrong password → clear error displayed and no output produced.
* Empty password → Unlock PDF action remains disabled.
* The downloaded unlocked PDF opens without requesting a password.

The UI also clearly states that the tool only removes protection when the user already knows the password and does not crack or bypass passwords.
