### PR TITLE
feat: add flip PDF operation

### DIFF
--- a/src/operations/flip-pdf/helpers.js
+++ b/src/operations/flip-pdf/helpers.js
@@ -1,0 +1,37 @@
+import { PDFDocument } from 'pdf-lib'
+
+/**
+ * @param {File} file
+ * @param {{mode:'horizontal'|'vertical'|'both'}} opts
+ */
+export async function flipPdf(file, opts, onProgress) {
+  const { mode = 'horizontal' } = opts || {}
+  let doc
+  try {
+    doc = await PDFDocument.load(await file.arrayBuffer())
+  } catch {
+    throw new Error('Could not read this PDF. Encrypted PDFs are not supported.')
+  }
+  const pages = doc.getPages()
+  const newDoc = await PDFDocument.create()
+
+  for (let i = 0; i < pages.length; i++) {
+    onProgress?.(i / pages.length, `Flipping page ${i + 1}...`)
+    const page = pages[i]
+    const { width, height } = page.getSize()
+    const embedded = await newDoc.embedPage(page)
+    const newPage = newDoc.addPage([width, height])
+    let drawOptions
+    if (mode === 'horizontal') {
+      drawOptions = { x: width, y: 0, xScale: -1, yScale: 1 }
+    } else if (mode === 'vertical') {
+      drawOptions = { x: 0, y: height, xScale: 1, yScale: -1 }
+    } else {
+      drawOptions = { x: width, y: height, xScale: -1, yScale: -1 }
+    }
+    newPage.drawPage(embedded, drawOptions)
+  }
+  onProgress?.(1, 'Saving...')
+  const bytes = await newDoc.save()
+  return new Blob([bytes], { type: 'application/pdf' })
+}

--- a/src/operations/flip-pdf/index.jsx
+++ b/src/operations/flip-pdf/index.jsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import Dropzone from '../../components/Dropzone.jsx'
+import Progress from '../../components/Progress.jsx'
+import Note from '../../components/Note.jsx'
+import Icon from '../../components/Icon.jsx'
+import DownloadButton from '../../components/DownloadButton.jsx'
+import { useJob } from '../../hooks/useJob.js'
+import { formatBytes, baseName } from '../../lib/format.js'
+import { flipPdf } from './helpers.js'
+import { usePdfPageCount } from '../../hooks/usePdfPageCount.js'
+
+export default function FlipPdf() {
+  const [file, setFile] = useState(null)
+  const [mode, setMode] = useState('horizontal')
+  const { running, progress, error, result, run, reset } = useJob()
+  const { pageCount } = usePdfPageCount(file)
+
+  const pick = (files) => {
+    setFile(files[0])
+    reset()
+  }
+  const go = () =>
+    run((p) =>
+      flipPdf(file, { mode }, p).then((blob) => ({
+        blob,
+        filename: `${baseName(file.name)}-flipped.pdf`,
+      })),
+    )
+
+  return (
+    <div className="space-y-6">
+      <Dropzone
+        onFiles={pick}
+        accept="application/pdf,.pdf"
+        multiple={false}
+        label="Drop a PDF here or click to browse"
+      />
+
+      {file && (
+        <>
+          <div className="card flex items-center gap-3 p-3">
+            <Icon name="fileText" className="h-5 w-5 text-brand-600" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+            <span className="text-xs text-slate-400">
+              {formatBytes(file.size)}
+              {pageCount != null && ` · ${pageCount} page${pageCount === 1 ? '' : 's'}`}
+            </span>
+          </div>
+
+          <div className="card p-4">
+            <label className="space-y-1">
+              <span className="field-label">Flip mode</span>
+              <select className="field-input" value={mode} onChange={(e) => setMode(e.target.value)}>
+                <option value="horizontal">Horizontal (mirror left ↔ right)</option>
+                <option value="vertical">Vertical (mirror top ↔ bottom)</option>
+                <option value="both">Both (mirror horizontally and vertically)</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button type="button" className="btn-primary" onClick={go} disabled={running}>
+              <Icon name="flip" className="h-4 w-4" />
+              Flip PDF
+            </button>
+            {result && <DownloadButton result={result} />}
+          </div>
+        </>
+      )}
+
+      {running && progress && <Progress value={progress.value} message={progress.message} />}
+      {error && (
+        <Note type="error" title="Flip failed">
+          {error}
+        </Note>
+      )}
+    </div>
+  )
+}

--- a/src/operations/flip-pdf/meta.js
+++ b/src/operations/flip-pdf/meta.js
@@ -1,0 +1,8 @@
+export default {
+  id: 'flip-pdf',
+  name: 'Flip PDF',
+  description: 'Mirror every page of a PDF horizontally, vertically, or both.',
+  category: 'pdf',
+  icon: 'flip',
+  order: 6,
+}


### PR DESCRIPTION
### Which issue does this close?
Closes #199

### What changed
Adds a new **Flip PDF** operation (`src/operations/flip-pdf/`) that mirrors every page of a PDF:
- **Horizontal** — mirrors left ↔ right
- **Vertical** — mirrors top ↔ bottom  
- **Both** — mirrors both axes

Uses `pdf-lib` with supported `xScale`/`yScale` negative scaling + translation (not the unsupported `transformationMatrix`). Preserves original page dimensions, supports multi-page PDFs, fully client-side with no new dependencies.

### Acceptance criteria
- [x] Pages are mirrored on the chosen axis in the exported PDF
- [x] Works on multi-page PDFs
- [x] Runs fully offline
- [x] Follows the plugin pattern: self-contained `src/operations/flip-pdf/{meta.js,index.jsx,helpers.js}`
- [x] Reuses shared components (Dropzone, useJob, Progress, Note, DownloadButton, usePdfPageCount)
- [x] Auto-discovered via registry globs (no central wiring)
- [x] Order: 6 (appears right after Rotate PDF)

### Checklist
- [x] Runs fully offline: no network calls, no CDNs, no external assets (strict CSP `connect-src 'self'`)
- [x] Follows the plugin pattern and reuses shared components where relevant
- [x] `npm run build` passes locally

### Proof
- `npm run lint` ✅ (0 errors, 19 pre-existing warnings)
- `npm run format:check` ✅
- `npm run build` ✅ (559 modules, 51 prerendered pages)
- `npm run test` ✅ (40 tests in 4 files)

**Manual verification** with asymmetric test PDF (400×300, 2 pages):
- Horizontal: LEFT ↔ RIGHT swapped, TOP/BOTTOM unchanged
- Vertical: TOP ↔ BOTTOM swapped, LEFT/RIGHT unchanged
- Both: both axes flipped
- Page count preserved (2 → 2), dimensions unchanged (400×300)