### PR TITLE
fix(edit-pdf): cover style changes with undo history

### DIFF
--- a/src/operations/edit-pdf/index.jsx
+++ b/src/operations/edit-pdf/index.jsx
@@ -287,7 +287,14 @@ export default function EditPdf() {
 
   const updateAnno = (id, patch) => setAnnos((prev) => prev.map((a) => (a.id === id ? { ...a, ...patch } : a)))
   // Apply a style change to the currently-selected annotation (if any).
-  const patchSelected = (patch) => selectedId && updateAnno(selectedId, patch)
+  // Goes through `commit` (not `updateAnno`) so style edits land in undo
+  // history. `updateAnno` stays raw on purpose: it also serves drag/resize
+  // `onChange`, which fires many updates per gesture.
+  const patchSelected = (patch) => {
+    if (!selectedId) return
+    const id = selectedId
+    commit((prev) => prev.map((a) => (a.id === id ? { ...a, ...patch } : a)))
+  }
 
   // ── erase (delete added items under the cursor) ──
   const distToSeg = (px, py, x1, y1, x2, y2) => {


### PR DESCRIPTION
Fixes #21.

Root cause: patchSelected delegated to updateAnno, which writes via raw setAnnos and bypasses the history-recording commit. All five style controls (color, width, font family, font size, bold/italic) therefore skipped the undo stack.

Change: patchSelected now applies its patch through commit. updateAnno is intentionally left raw since it also serves AnnotationBox drag/resize onChange, where per-move commits would flood the undo stack.

Tests: eslint clean (0 errors, warnings unchanged pre/post), unit suite 40/40 pass, updater semantics simulated (style change then undo restores prior style).